### PR TITLE
misc: Move version to version.tcl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ _$*
 *.ln
 core
 # CVS default ignores end
+
+release

--- a/build-beta-release.sh
+++ b/build-beta-release.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+version=`grep -o "[1-9]*\.[0-9\.]*" de1plus/version.tcl`
+
+echo "Releasing $version"
+
+if [ -e release/$version ] ; then
+	echo "Removing old release of identical version"
+    rm -r release/$version
+fi
+
+
+mkdir -p release/$version/source
+
+echo "Copying support files"
+
+cp -R misc/desktop_app/* release/$version/
+cp -R de1plus/* release/$version/source
+
+echo "Arranging source"
+ln -vs `pwd`/release/$version/source release/$version/osx/src
+ln -vs `pwd`/release/$version/source release/$version/win32/src
+ln -vs `pwd`/release/$version/source release/$version/linux/src
+
+chmod +x release/$version/linux/undroidwish/undroidwish-*
+
+echo "Packing zips. This might take a while"
+zip -rq "release/$version/decent_osx.zip" release/$version/osx/*
+zip -rq "release/$version/decent_win.zip" release/$version/win32/*
+zip -rq "release/$version/decent_linux.zip" release/$version/linux/*
+zip -rq "release/$version/decent_source.zip" release/$version/source/*
+
+echo "build created, please push the tag by running"
+echo "git tag $version"
+echo "git push origin --tags"

--- a/de1plus/de1plus.tcl
+++ b/de1plus/de1plus.tcl
@@ -3,7 +3,7 @@
 encoding system utf-8
 cd "[file dirname [info script]]/"
 source "pkgIndex.tcl"
-package ifneeded de1app 1.32 {}
+source "version.tcl"
 package provide de1plus 1.0
 package require de1_main
 de1_ui_startup

--- a/de1plus/misc.tcl
+++ b/de1plus/misc.tcl
@@ -127,6 +127,7 @@ proc make_de1_dir {} {
         autopair_with_de1.tcl *
         autopair_with_de1plus.tcl *
         history_export.tcl *
+		version.tcl *
 
         history/info.txt *
         history/export/readme.txt *

--- a/de1plus/version.tcl
+++ b/de1plus/version.tcl
@@ -1,0 +1,2 @@
+package ifneeded de1app 1.33.0 {}
+


### PR DESCRIPTION
To be able to change the version easily programmatically we are moving the version
definition to its own minimal version.tcl file.
So far the version was defined in the de1plus.tcl where there are many things that could
break when changed automatically.

Signed-off-by: Mimoja <git@mimoja.de>