### PR TITLE
comms: Cleanup connection managment to allow for use with different connection modes

### DIFF
--- a/de1plus/autopair_with_de1.tcl
+++ b/de1plus/autopair_with_de1.tcl
@@ -44,10 +44,9 @@ if {$tk != ""} {
 	pack .hello
 }
 
-proc fill_ble_listbox {} {}
+proc fill_de1_listbox {} {}
 set ::de1_device_list {}
 set ::settings(bluetooth_address) {}
-ble_find_de1s
 vwait ::de1_device_list
 
 set success 1

--- a/de1plus/gui.tcl
+++ b/de1plus/gui.tcl
@@ -1078,8 +1078,6 @@ proc de1_connected_state { {hide_delay 0} } {
 			}
 		} else {
 			if {$since_last_ping > 59} {
-				#ble_find_de1s
-				#ble_connect_to_de1
 				return [translate "Disconnected"]
 			}
 			return [subst {[translate "Disconnected"] : $since_last_ping}]
@@ -1124,21 +1122,6 @@ proc display_popup_android_message_if_necessary {intxt} {
 
 
 proc update_onscreen_variables { {state {}} } {
-
-	#update_chart
-
-	#save_settings
-
-	#set since_last_ping [expr {[clock seconds] - $::de1(last_ping)}]
-	#if {$since_last_ping > 3} {
-		#set ::de1(last_ping) [clock seconds]
-		#if {$::android == 1} {
-			#set ::de1(found) 0
-			#ble_find_de1s
-			#ble_connect_to_de1
-		#}
-
-	#}
 
 	if {$::android == 0} {
 
@@ -2018,7 +2001,7 @@ proc ui_startup {} {
 
 	load_settings
 	setup_environment
-	bluetooth_connect_to_devices
+	connect_to_devices
 	
 	if {[ifexists ::settings(enable_shot_history_export)] == "1"} {
 		shot_history_export
@@ -2027,7 +2010,6 @@ proc ui_startup {} {
 	if {[ifexists ::settings(mark_most_popular_profiles_used)] == "1"} {
 		shot_history_count_profile_use
 	}
-	#ble_find_de1s
 	
 	setup_images_for_first_page
 	setup_images_for_other_pages

--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -125,7 +125,6 @@ array set ::de1 {
 	steam_time_max 250
 	last_ping 0
 	steam_heater_temperature 150
-	connectivity "ble"
 }
 
 set ::de1(last_ping) [clock seconds]
@@ -413,6 +412,7 @@ array set ::settings {
 	force_acaia_heartbeat 0
 	comms_debugging 0
 	scale_stop_at_half_shot 0
+	connectivity "ble"
 }
 
 if {[de1plus]} {
@@ -428,8 +428,8 @@ if {$::android != 1} {
 set ::settings(preinfusion_guarantee) 0
 
 set ::de1_device_list {}
-if { $settings(bluetooth_address) != ""} {
-	append_to_de1_list $settings(bluetooth_address) "DE1" "ble"
+if { $::settings(bluetooth_address) != ""} {
+	append_to_de1_list $::settings(bluetooth_address) "DE1"  $::settings(connectivity)
 }
 
 #msg "init was run '$::settings(scale_type)'"
@@ -852,7 +852,7 @@ proc start_idle {} {
 
 	if {$::de1(device_handle) == 0} {
 		update_de1_state "$::de1_state(Idle)\x0"
-		ble_connect_to_de1
+		comms_connect_to_de1
 		return
 	}
 

--- a/de1plus/misc.tcl
+++ b/de1plus/misc.tcl
@@ -108,6 +108,7 @@ proc make_de1_dir {} {
         de1plus.tcl *
         de1.tcl *
         de1_comms.tcl *
+        usb.tcl *
         gui.tcl *
         machine.tcl *
         utils.tcl *

--- a/de1plus/pkgIndex.tcl
+++ b/de1plus/pkgIndex.tcl
@@ -9,3 +9,5 @@ package ifneeded de1_creatormain 1.0 [list source [file join "./" creatormain.tc
 package ifneeded de1_machine 1.0 [list source [file join "./" machine.tcl]]
 package ifneeded de1_misc 1.0 [list source [file join "./" misc.tcl]]
 package ifneeded de1_updater 1.0 [list source [file join "./" updater.tcl]]
+package ifneeded de1_usb 1.0 [list source [file join "./" usb.tcl]]
+

--- a/de1plus/skins/default/de1_skin_settings.tcl
+++ b/de1plus/skins/default/de1_skin_settings.tcl
@@ -781,7 +781,7 @@ add_de1_text "settings_4" 55 970 -text [translate "Connect"] -font Helv_10_bold 
 		add_de1_widget "settings_4" listbox 55 1150 { 
 				set ::ble_listbox_widget $widget
 				bind $::ble_listbox_widget <<ListboxSelect>> ::change_bluetooth_device
-				fill_ble_listbox
+				fill_de1_listbox
 			} -background #fbfaff -font global_font -bd 0 -height 3 -width 19 -foreground #d3dbf3 -borderwidth 0 -selectborderwidth 0  -relief flat -highlightthickness 0 -selectmode single -selectbackground #c0c4e1
 
 	add_de1_text "settings_4" 680 1100 -text [translate "Scale"] -font Helv_7_bold -fill "#7f879a" -justify "left" -anchor "nw"
@@ -856,10 +856,6 @@ add_de1_text "settings_3" 1304 1080  -text [translate "Water level"] -font Helv_
 
 	#add_de1_variable "settings_4" 50 760 -text "" -font Helv_7 -fill "#4e85f4" -anchor "nw" -width 800 -justify "left" -textvariable {[translate "Refill at:"] $::settings(water_refill_point)[translate mm]}
 	#add_de1_variable "settings_4" 1240 760 -text "" -font Helv_7 -fill "#7f879a" -anchor "ne" -width [rescale_y_skin 1000] -justify "right" -textvariable {[translate "Now:"] [round_to_integer $::de1(water_level)][translate mm]}
-
-# bluetooth scan
-#add_de1_text "settings_4" 2230 980 -text [translate "Search"] -font Helv_10_bold -fill "#FFFFFF" -anchor "center"
-#add_de1_button "settings_4" {set ::de1_device_list ""; say [translate {search}] $::settings(sound_button_in); ble_find_de1s} 1910 890 2550 1080
 
 set enable_spoken_buttons 0
 if {$enable_spoken_buttons == 1} {

--- a/de1plus/usb.tcl
+++ b/de1plus/usb.tcl
@@ -1,0 +1,63 @@
+package provide de1_usb 1.0
+
+proc usb_scan_devices {} {
+	set devices [usbserial]
+	foreach {device} $devices {
+		append_to_de1_list $device "DE1" "usb"
+	}
+	if {$::scanning == 1} {
+		after 200 usb_scan_devices
+	}
+}
+
+
+proc usb_connect_to_de1 {} {
+	msg "usb_connect_to_de1"
+
+	if {$::settings(connectivity) != "usb" || $::settings(bluetooth_address) == "" } {
+		error "usb_connect_to_de1 called but connectivity wrong: $::settings(connectivity) $::settings(bluetooth_address)"
+		return
+	}
+
+	if {$::currently_connecting_de1_handle != 0} {
+		catch {
+			close $::currently_connecting_de1_handle
+		}
+		set ::currently_connecting_de1_handle 0
+	}
+
+	catch {
+		msg "initiating USB connection to  $::settings(bluetooth_address)"
+		set ::currently_connecting_de1_handle [usbserial $::settings(bluetooth_address)]
+	}
+
+	if {$::currently_connecting_de1_handle > 0} {
+		usb_connect_handler $::settings(bluetooth_address)
+	} else {
+		msg "usb connect failed"
+	}
+}
+
+
+proc usb_connect_handler {usb_path} {
+	msg "usb_connect_handler"
+
+	set ::de1(device_handle) $::currently_connecting_de1_handle
+	set ::currently_connecting_de1_handle 0
+
+	# install readable event handler
+	fileevent $::de1(device_handle) readable [list channel_read_handler $::de1(device_handle)]
+	fconfigure $::de1(device_handle) -mode 115200,n,8,1
+	chan configure $::de1(device_handle) -translation {auto lf}
+	chan configure $::de1(device_handle) -buffering line
+	chan configure $::de1(device_handle) -blocking 0
+
+	de1_connect_handler $::de1(device_handle) "$usb_path" "DE1" "usb"
+}
+
+proc usb_close_de1 {} {
+    catch {
+		close $::de1(device_handle)
+	}
+	set ::de1(device_handle) 0
+}


### PR DESCRIPTION
comms: Cleanup connection managment to allow for use with different connection modes

So far we were only able to connect to the DE1 via BLE. To be able to remove this
restriction we need not only to safe the connectivity mode as well as the but build
generic versions of connection managment functions.
In this commit we also add the ability to search for USB devices and connect to them.

Signed-off-by: Mimoja <git@mimoja.de>