### PR TITLE
machine: add hidden setting to lock the screen if wanted

### DIFF
--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -418,6 +418,7 @@ array set ::settings {
 	force_acaia_heartbeat 0
 	comms_debugging 0
 	scale_stop_at_half_shot 0
+	lock_screen_during_screensaver 0
 }
 
 if {[de1plus]} {
@@ -855,6 +856,12 @@ proc start_water {} {
 proc start_idle {} {
 	msg "Tell DE1 to start to go IDLE (and stop whatever it is doing)"
 
+	# Ensure we are not locking the screen during use.
+	# This is only relevant when waking up the machine
+	if  {[sdltk screensaver] == 1} {
+		sdltk screensaver off
+	}
+
 	if {$::de1(device_handle) == 0} {
 		update_de1_state "$::de1_state(Idle)\x0"
 		ble_connect_to_de1
@@ -943,6 +950,10 @@ proc start_sleep {} {
 		#after [expr {1000 * $::settings(water_max_time)}] {page_display_change "water" "off"}
 		after 200 [list update_de1_state "$::de1_state(GoingToSleep)\x0"]
 		after 800 [list update_de1_state "$::de1_state(Sleep)\x0"]
+	}
+
+	if {$::settings(lock_screen_during_screensaver) == 1} {
+		sdltk screensaver on
 	}
 }
 


### PR DESCRIPTION
We are seeing customers turning off their machines over night, not trusting the
power usage. To accomodate for their usecase we are disabeling the screenlock if
requested.

Signed-off-by: Mimoja <git@mimoja.de>