### PR TITLE
Add "keep awake" option for scheduler

### DIFF
--- a/de1plus/gui.tcl
+++ b/de1plus/gui.tcl
@@ -927,7 +927,7 @@ proc show_going_to_sleep_page  {} {
 		return
 	}
 
-    if {[ifexists ::app_updating] == 1} {
+    	if {[ifexists ::app_updating] == 1} {
 		msg "delaying screen saver because tablet app is updating"
 		delay_screen_saver
 		return
@@ -937,7 +937,16 @@ proc show_going_to_sleep_page  {} {
 		msg "delaying screen saver because firmware is updating"
 		delay_screen_saver
 		return
-	}	
+	}
+	
+	# make scheduler work on "keep awake" logic
+	if {[ifexists ::scheduler_awake] == 1) {
+		msg "delaying screen saver 60 sec because of scheduler"
+		stop_screen_saver_timer
+                if {$::settings(screen_saver_delay) != 0 } {
+                        set ::screen_saver_alarm_handle [after 60000 "show_going_to_sleep_page"]
+		return
+	}
 
 	puts "show_going_to_sleep_page"
  	if {$::de1(current_context) == "sleep" || $::de1(current_context) == "saver"} {

--- a/de1plus/gui.tcl
+++ b/de1plus/gui.tcl
@@ -940,11 +940,12 @@ proc show_going_to_sleep_page  {} {
 	}
 	
 	# make scheduler work on "keep awake" logic
-	if {[ifexists ::scheduler_awake] == 1) {
+	if {[ifexists ::scheduler_awake] == 1} {
 		msg "delaying screen saver 60 sec because of scheduler"
 		stop_screen_saver_timer
                 if {$::settings(screen_saver_delay) != 0 } {
                         set ::screen_saver_alarm_handle [after 60000 "show_going_to_sleep_page"]
+		}
 		return
 	}
 

--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -193,6 +193,11 @@ proc set_alarms_for_de1_wake_sleep {} {
 
 		set sleep_seconds [expr {[next_alarm_time $::settings(scheduler_sleep)] - [clock seconds]}]
 		set ::alarms_for_de1_sleep [after [expr {1000 * $sleep_seconds}] scheduler_sleep]
+		
+		# if we are in the middle of the scheduled period at startup, set the awake flag if using new scheduler logic
+		if {[ifexists ::settings(scheduler_logic)] == 1 && $wake_seconds > $sleep_seconds} {
+			set ::scheduler_awake 1
+		}
 
 		#msg "Wake schedule set for [next_alarm_time $::settings(scheduler_wake)] in $wake_seconds seconds"
 		#msg "Sleep schedule set for [next_alarm_time $::settings(scheduler_sleep)] in $sleep_seconds seconds"
@@ -218,7 +223,7 @@ proc scheduler_sleep {} {
 	
 	# if user has chosen new scheduler logic, clear "keep awake" flag (which will allow machine to sleep per idle timer), else immediately sleep
 	if {[ifexists ::settings(scheduler_logic)] == 1} {
-                unset -nocomplain ::scheduler_awake
+                unset ::scheduler_awake
         } else {
 		start_sleep
 	}

--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -218,7 +218,7 @@ proc scheduler_sleep {} {
 	
 	# if user has chosen new scheduler logic, clear "keep awake" flag (which will allow machine to sleep per idle timer), else immediately sleep
 	if {[ifexists ::settings(scheduler_logic)] == 1} {
-                unset ::scheduler_awake
+                unset -nocomplain ::scheduler_awake
         } else {
 		start_sleep
 	}

--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -201,7 +201,12 @@ proc set_alarms_for_de1_wake_sleep {} {
 
 proc scheduler_wake {} {
 	msg "Scheduled wake occurred at [clock format [clock seconds]]"
-	set ::scheduler_awake 1
+	
+	# set "keep awake" flag if user has chosen new scheduler logic
+	if {[ifexists ::settings(scheduler_logic)] == 1} {
+                set ::scheduler_awake 1
+        }
+	
 	start_idle
 
 	# after alarm has occurred go ahead and set the alarm for tommorrow
@@ -210,9 +215,14 @@ proc scheduler_wake {} {
 
 proc scheduler_sleep {} {
 	msg "Scheduled end occurred at [clock format [clock seconds]]"
-	unset ::scheduler_awake
-	#start_sleep
-
+	
+	# if user has chosen new scheduler logic, clear "keep awake" flag (which will allow machine to sleep per idle timer), else immediately sleep
+	if {[ifexists ::settings(scheduler_logic)] == 1} {
+                unset ::scheduler_awake
+        } else {
+		start_sleep
+	}
+	
 	# after alarm has occurred go ahead and set the alarm for tommorrow
 	after 2000 set_alarms_for_de1_wake_sleep
 }

--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -200,18 +200,20 @@ proc set_alarms_for_de1_wake_sleep {} {
 }
 
 proc scheduler_wake {} {
-	msg "Scheduled wake occured at [clock format [clock seconds]]"
+	msg "Scheduled wake occurred at [clock format [clock seconds]]"
+	set ::scheduler_awake 1
 	start_idle
 
-	# after alarm has occured go ahead and set the alarm for tommorrow
+	# after alarm has occurred go ahead and set the alarm for tommorrow
 	after 2000 set_alarms_for_de1_wake_sleep
 }
 
 proc scheduler_sleep {} {
-	msg "Scheduled sleep occured at [clock format [clock seconds]]"
-	start_sleep
+	msg "Scheduled end occurred at [clock format [clock seconds]]"
+	unset ::scheduler_awake
+	#start_sleep
 
-	# after alarm has occured go ahead and set the alarm for tommorrow
+	# after alarm has occurred go ahead and set the alarm for tommorrow
 	after 2000 set_alarms_for_de1_wake_sleep
 }
 


### PR DESCRIPTION
If the user adds `scheduler_logic 1` to settings.tdb, the following changes are implemented:

1. In vars.tcl, the flag `scheduler_awake` is set to 1 at the scheduled wake time, and unset at scheduled sleep time. At the scheduled sleep time, the machine does not immediately sleep (that instead is left for the idle timer to deal with).
2. In gui.tcl, if `scheduler_awake` is set to 1, don't sleep (or defer sleep for 60 seconds, to be more precise). Once `scheduler_awake` is unset, the machine will sleep per its regular settings.

Because these changes are implemented only if the user has chosen to edit settings.tdb, they hopefully are non-controversial.

Context: https://3.basecamp.com/3671212/buckets/7351439/messages/1529734776#__recording_3263004744