### PR TITLE
Add minimal webserver listening on 8080 that allows to toggle the power

### DIFF
--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -418,6 +418,10 @@ array set ::settings {
 	comms_debugging 0
 	scale_stop_at_half_shot 0
 	lock_screen_during_screensaver 0
+	webserver_enabled 0
+	webserver_magic_phrase "I really want an unsecure (non-SSL) Webserver on my coffee machine"
+	webserver_magic_phrase_confirm ""
+	webserver_port 8080
 }
 
 # default de1plus skin

--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -419,9 +419,10 @@ array set ::settings {
 	scale_stop_at_half_shot 0
 	lock_screen_during_screensaver 0
 	webserver_enabled 0
-	webserver_magic_phrase "I really want an unsecure (non-SSL) Webserver on my coffee machine"
+	webserver_magic_phrase "I really want an unsecured (non-SSL) Webserver on my coffee machine"
 	webserver_magic_phrase_confirm ""
 	webserver_port 8080
+	webserver_authentication_key "ChangeMe"
 }
 
 # default de1plus skin

--- a/de1plus/main.tcl
+++ b/de1plus/main.tcl
@@ -20,6 +20,7 @@ package require de1_vars
 package require de1_binary
 package require de1_utils 
 package require de1_machine
+package require de1_webserver
 package require math::statistics
 package require http 2.5
 

--- a/de1plus/pkgIndex.tcl
+++ b/de1plus/pkgIndex.tcl
@@ -9,3 +9,4 @@ package ifneeded de1_creatormain 1.0 [list source [file join "./" creatormain.tc
 package ifneeded de1_machine 1.0 [list source [file join "./" machine.tcl]]
 package ifneeded de1_misc 1.0 [list source [file join "./" misc.tcl]]
 package ifneeded de1_updater 1.0 [list source [file join "./" updater.tcl]]
+package ifneeded de1_webserver 1.0 [list source [file join "./" webserver.tcl]]

--- a/de1plus/utils.tcl
+++ b/de1plus/utils.tcl
@@ -325,6 +325,10 @@ proc setup_environment {} {
     #}
 
     ############################################
+
+    if { $::settings(webserver_enabled) } {
+		start_webserver
+	}
 }
 
 proc check_if_battery_low_and_give_message {} {

--- a/de1plus/webserver.tcl
+++ b/de1plus/webserver.tcl
@@ -16,7 +16,10 @@ proc start_webserver {} {
         return
     }
 
-
+    if {$::settings(webserver_authentication_key) == "ChangeMe"} {
+        after 2000 {error "Please change the Webserver auth key!"}
+        return
+    }
     # Define handlers
     ::wibble::handle /on togglePowerOn
     ::wibble::handle /off togglePowerOff
@@ -28,7 +31,35 @@ proc start_webserver {} {
     }
 }
 
+proc ::wibble::check_auth {state} {
+    set auth [dict getnull $state request query auth]
+    set auth [lindex $auth 1]
+
+    if {$auth eq ""} {
+        return [unauthorized $state]
+    }
+
+    if {$auth != $::settings(webserver_authentication_key)} {
+        return [unauthorized $state]
+    }
+
+    return true;
+}
+
+proc ::wibble::unauthorized {state} {
+    dict set response status 403
+    dict set state response header content-type "" {application/json charset utf-8}
+    dict set response content "{status: \"unauthorized\"}"
+    sendresponse $response
+    return false;
+}
+
+
 proc ::wibble::togglePowerOn {state} {
+    if { ![check_auth $state] } {
+        return;
+    }
+
     start_idle
 
     dict set response status 200
@@ -38,6 +69,10 @@ proc ::wibble::togglePowerOn {state} {
 }
 
 proc ::wibble::togglePowerOff {state} {
+    if { ![check_auth $state] } {
+        return;
+    }
+    
     start_sleep
 
     dict set response status 200

--- a/de1plus/webserver.tcl
+++ b/de1plus/webserver.tcl
@@ -1,0 +1,47 @@
+package provide de1_webserver 1.0
+
+package require wibble
+package require rl_json
+package require de1_machine
+
+proc start_webserver {} {
+
+    if {$::settings(webserver_enabled) == 0} {
+        after 2000 {error "Webserver start requested but not enabled in the settings"}
+        return 
+    }
+
+    if {$::settings(webserver_magic_phrase_confirm) != $::settings(webserver_magic_phrase)} {
+        after 2000 {error "Webserver confirmation string not found or incorrect"}
+        return
+    }
+
+
+    # Define handlers
+    ::wibble::handle /on togglePowerOn
+    ::wibble::handle /off togglePowerOff
+    ::wibble::handle / notfound
+
+    # Start a server and enter the event loop if not already there.
+    catch {
+        ::wibble::listen 8080
+    }
+}
+
+proc ::wibble::togglePowerOn {state} {
+    start_idle
+
+    dict set response status 200
+    dict set state response header content-type "" {application/json charset utf-8}
+    dict set response content "{status: \"ok\"}"
+    sendresponse $response
+}
+
+proc ::wibble::togglePowerOff {state} {
+    start_sleep
+
+    dict set response status 200
+    dict set state response header content-type "" {application/json charset utf-8}
+    dict set response content "{status: \"ok\"}"
+    sendresponse $response
+}


### PR DESCRIPTION
Tested on windows and on device for multiple hours and shots over a single day. Supports on / off.
Instead of toggle it us using dedicated endpoints to recude the risk of accidental use.

Interface is absolutely up for discussion together with everything else. Please dont merge without proper discussion. 

Signed-off-by: Mimoja <git@mimoja.de>