### PR TITLE
Print settings when selecting an extension

### DIFF
--- a/de1plus/gui.tcl
+++ b/de1plus/gui.tcl
@@ -2031,11 +2031,12 @@ proc ui_startup {} {
 	}
 	#ble_find_de1s
 	
+	load_plugins
+	
 	setup_images_for_first_page
 	setup_images_for_other_pages
 	.can itemconfigure splash -state hidden
 
-	load_plugins
 
 	#after $::settings(timer_interval) 
 	update_onscreen_variables

--- a/de1plus/plugins/example/plugin.tcl
+++ b/de1plus/plugins/example/plugin.tcl
@@ -1,21 +1,52 @@
+
+# Change package name for you extension / plugin
 set plugin_name "example"
 
+# These are chown in the plugin selection page
 set ::plugins::${plugin_name}::author "JoJo"
 set ::plugins::${plugin_name}::contact "email@coffee-mail.de"
 set ::plugins::${plugin_name}::version 1.0
-set ::plugins::${plugin_name}::description "Minimal plugin to showcase the interface"
+set ::plugins::${plugin_name}::description "Minimal plugin to showcase the interface of the plugin / extensions system."
+
+# preload is called on app start even if the plugin is disabled. Can be used to show
+# dynamic informations on the settings overview. Please dont put logic here
+# needs to return the page you want to be shown first
+proc ::plugins::${plugin_name}::preload {} {
+    # Unique name per page
+    set page_name "plugin_example_page_default"
+
+    # Background image and "Done" button
+    add_de1_page "$page_name" "settings_message.png" "default"
+    add_de1_text $page_name 1280 1310 -text [translate "Done"] -font Helv_10_bold -fill "#fAfBff" -anchor "center"
+	add_de1_button $page_name {say [translate {Done}] $::settings(sound_button_in); fill_extensions_listbox; page_to_show_when_off extensions; set_extensions_scrollbar_dimensions}  980 1210 1580 1410 ""
+
+    # Headline
+    add_de1_text $page_name 1280 300 -text [translate "Example Plugin"] -font Helv_20_bold -width 1200 -fill "#444444" -anchor "center" -justify "center"
+
+    # The actual content. Here a list of all settings for this plugin
+    set content_textfield [add_de1_text $page_name 600 380 -text  "" -font global_font -width 600 -fill "#444444" -anchor "nw" -justify "left" ]
+    set description ""
+    foreach {key value} [array get ::plugins::example::settings] {
+		set description "$description\n$key: $value"
+  	}
+    .can itemconfigure $content_textfield -text $description
+
+    return $page_name
+}
 
 proc on_espresso_end {old new} {
     borg toast "espresso ended"
 }
 
 proc on_function_called {call code result op} {
-    borh toast "start_sleep called!"
+    borg toast "start_sleep called!"
 }
 
-# optional
-# the file will be sourced and the main will be called.
-# The main is therefore optional
+# This file will be sourced to display meta-data. Dont put any code into the
+# general scope as there are no quarantees about when it will be run.
+# For security reasons it is highly unlikely you will find the plugin in the
+# official distribution if you are not beeing run from your main
+# REQUIRED
 proc ::plugins::${plugin_name}::main {} {
     msg "Accessing loaded settings: $::plugins::example::settings(amazing_feature)"
     msg "Changing settings"

--- a/de1plus/plugins/visualizer_upload/plugin.tcl
+++ b/de1plus/plugins/visualizer_upload/plugin.tcl
@@ -9,7 +9,7 @@ set ::plugins::${plugin_name}::contact "coffee-plugins@mimoja.de"
 set ::plugins::${plugin_name}::version 1.0
 set ::plugins::${plugin_name}::description "Upload your last shot to visualizer.coffee"
 
-proc upload {content} {
+proc ::plugins::${plugin_name}::upload {content} {
     msg "uploading shot"
     borg toast "Uploading Shot"
     http::register https 443 [list ::tls::socket -servername $::plugins::visualizer_upload::settings(visualizer_url)]
@@ -34,6 +34,12 @@ proc upload {content} {
         set answer [http::data $token]
         msg "status: $status"
         msg "answer $answer"
+        if {[string length $answer] == 0} {
+            msg "No id transmitted"
+            borg toast "Upload failed!"
+            return
+        }
+
 	} err] != 0} {
         msg "Could not upload shot! $err"
         borg toast "Upload failed!"
@@ -44,15 +50,15 @@ proc upload {content} {
     http::cleanup $token
 }
 
-proc uploadShotData {old new} {
-    #if {[espresso_elapsed length] > 5 && [espresso_pressure length] > 5} {
+proc ::plugins::${plugin_name}::uploadShotData {old new} {
+    if {[espresso_elapsed length] > 5 && [espresso_pressure length] > 5} {
         set espresso_data [format_espresso_for_history]
         upload $espresso_data
-    #}
+    }
 }
 
 
 proc ::plugins::${plugin_name}::main {} {
-    register_state_change_handler Espresso Idle uploadShotData   
+    register_state_change_handler Espresso Idle ::plugins::visualizer_upload::uploadShotData   
 }
 

--- a/de1plus/plugins/web_api/settings.tdb
+++ b/de1plus/plugins/web_api/settings.tdb
@@ -1,4 +1,4 @@
-webserver_magic_phrase "I really want an unsecure (non-SSL) Webserver on my coffee machine"
+webserver_magic_phrase "I really want an unsecured (non-SSL) Webserver on my coffee machine"
 webserver_magic_phrase_confirm ""
 webserver_port 8080
 webserver_authentication_key "ChangeMe"

--- a/de1plus/skins/Insight/skin.tcl
+++ b/de1plus/skins/Insight/skin.tcl
@@ -1,4 +1,4 @@
-set ::debugging 0
+set ::debugging 1
 
 msg "rtl $::de1(language_rtl)"
 

--- a/de1plus/skins/default/de1_skin_settings.tcl
+++ b/de1plus/skins/default/de1_skin_settings.tcl
@@ -656,14 +656,19 @@ add_de1_text "settings_4" 50 220 -text [translate "Update App"] -font Helv_10_bo
 	add_de1_button "settings_4" {say [translate {Extensions}] $::settings(sound_button_in); fill_extensions_listbox; page_to_show_when_off extensions; ; set_extensions_scrollbar_dimensions}  1910 520 2530 720
 
 		add_de1_text "extensions" 1280 300 -text [translate "Extensions"] -font Helv_20_bold -width 1200 -fill "#444444" -anchor "center" -justify "center" 
-		add_de1_widget "extensions" listbox 900 480 { 
+		add_de1_widget "extensions" listbox 340 480 { 
 			set ::extensions_widget $widget
 			bind $widget <<ListboxSelect>> ::toggle_extension
 			fill_extensions_listbox
 		} -background #fbfaff -xscrollcommand {scale_prevent_horiz_scroll $::extensions_widget} -yscrollcommand {scale_scroll_new $::extensions_widget ::extensions_slider} -font global_font -bd 0 -height [expr {int(9 * $::globals(listbox_length_multiplier))}] -width 26 -foreground #d3dbf3 -borderwidth 0 -selectborderwidth 0  -relief flat -highlightthickness 0 -selectmode single  -selectbackground #c0c4e1
 
+		set ::extensions_metadata [add_de1_text "extensions" 1200 480 -text  "" -font global_font -width 600 -fill "#444444" -anchor "nw" -justify "left" ]
+
 		set ::extensions_slider 0
 		set ::extensions_scrollbar [add_de1_widget "extensions" scale 10000 1 {} -from 0 -to 1.0 -bigincrement 0.2 -background "#d3dbf3" -borderwidth 1 -showvalue 0 -resolution .01 -length [rescale_x_skin 400] -width [rescale_y_skin 150] -variable ::language_slider -font Helv_10_bold -sliderlength [rescale_x_skin 125] -relief flat -command {listbox_moveto $::extensions_widget $::extensions_slider}  -foreground #FFFFFF -troughcolor "#f7f6fa" -borderwidth 0  -highlightthickness 0]
+
+		add_de1_text "extensions" 2200 1150 -text [translate "⚙️Settings"] -font Helv_11_bold -fill "#000000" -anchor "center" 
+		add_de1_button "extensions" {fill_plugin_settings}  2100 1010 2330 1310
 
 		# this moves the scrollbar to the right of the extensions listbox, and sets its height correctly
 		# this can't be done until the page is rendered, because the windowing system doesn't know ahead of time the true dimensions of the listbox, not until it is rendered

--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -2287,9 +2287,44 @@ proc toggle_extension {} {
 
 	set plugin [lindex [available_plugins] $stepnum ]
 
+	source_plugin $plugin
+	set description ""
+
+	if {[info proc ::plugins::${plugin}::preload] != ""} {
+		set description [translate "Configurable: Yes"]
+	} else {
+		set description [translate "Configurable: No"]
+	}
+
+	foreach {name value} { "Version: " version "Author: " author "Contact: " contact "" description} {
+		set conf [set ::plugins::${plugin}::${value}]
+		if { $conf != {} } {
+			set description "$description\n[translate $name]$conf"
+		}
+	}
+	.can itemconfigure $::extensions_metadata -text $description
+
 	toggle_plugin $plugin
 
 	fill_extensions_listbox
+	$::extensions_widget selection set $stepnum;
+	make_current_listbox_item_blue $::extensions_widget 
+
+}
+
+proc fill_plugin_settings {} {
+	set stepnum [$::extensions_widget curselection]
+	if {$stepnum == ""} {
+		borg toast [translate "No Extensions selected"]
+		return
+	}
+
+	set plugin [lindex [available_plugins] $stepnum]
+
+	if {[info proc ::plugins::${plugin}::preload] != ""} {
+		set next_page [set ::plugins::${plugin}::ui_entry]
+		page_to_show_when_off $next_page
+	}
 }
 
 proc fill_extensions_listbox {} {
@@ -2298,7 +2333,6 @@ proc fill_extensions_listbox {} {
 
 	$widget delete 0 99999
 	set cnt 0
-	set current_profile_number 9999
 	set current 0
 
 	foreach {plugin} [available_plugins] {
@@ -2320,7 +2354,6 @@ proc fill_extensions_listbox {} {
 		incr cnt
 	}
 
-	$widget selection set $current;
 	$::extensions_widget yview $current
 }
 


### PR DESCRIPTION
As we do not want to source and extension code without the
uses consent we can not display any dynamic variables.
But: We can use the additional space to show the saved settings
that are in use. This allows us to double-check the current configuration
before activating a plugin. We can not easily open the settings file
in an external android editor without the risk of exposing user data to
3rd party apps without the user consent. I personally dont think we can
solve that from within the app (for now). User will still need to edit their
plugin settings from within the filebrowser / adc / their app of choice.

Signed-off-by: Mimoja <git@mimoja.de>