### PR TITLE
binary: Draw first state change

### DIFF
--- a/de1plus/binary.tcl
+++ b/de1plus/binary.tcl
@@ -1432,7 +1432,7 @@ proc update_de1_shotvalue {packed} {
 	if {$::previous_FrameNumber != [ifexists ShotSample(FrameNumber)]} {
 		# draw a vertical line at each frame change
 
-		if {$::previous_FrameNumber > 0} {
+		if {$::previous_FrameNumber >= 0} {
 			# don't draw a line a the first frame change
 			set ::state_change_chart_value [expr {$::state_change_chart_value * -1}]
 		}


### PR DESCRIPTION
The $::previous_FrameNumber gets initialized with -1 instead of 0.
Therefore checking for 0 as unitialized state is not providing the
expected results leading to the first state change line not beeing drawn.

This commit fixes this behaviour by changing the check.

Signed-off-by: Mimoja <git@mimoja.de>