### PR TITLE
Shot file improvements

### DIFF
--- a/de1plus/binary.tcl
+++ b/de1plus/binary.tcl
@@ -1432,7 +1432,7 @@ proc update_de1_shotvalue {packed} {
 	if {$::previous_FrameNumber != [ifexists ShotSample(FrameNumber)]} {
 		# draw a vertical line at each frame change
 
-		if {$::previous_FrameNumber > 0} {
+		if {$::previous_FrameNumber >= 0} {
 			# don't draw a line a the first frame change
 			set ::state_change_chart_value [expr {$::state_change_chart_value * -1}]
 		}

--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -3129,9 +3129,19 @@ proc format_espresso_for_history {} {
 		append espresso_data "espresso_temperature_mix {[espresso_temperature_mix range 0 end]}\n"
 		append espresso_data "espresso_water_dispensed {[espresso_water_dispensed range 0 end]}\n"
 
+		append espresso_data "espresso_pressure_delta {[espresso_pressure_delta range 0 end]}\n"	
+		append espresso_data "espresso_flow_delta_negative {[espresso_flow_delta_negative range 0 end]}\n"	
+		append espresso_data "espresso_flow_delta_negative_2x {[espresso_flow_delta_negative_2x range 0 end]}\n"	
+
+		append espresso_data "espresso_resistance {[espresso_resistance range 0 end]}\n"	
+		append espresso_data "espresso_resistance_weight {[espresso_resistance_weight range 0 end]}\n"	
+
+		append espresso_data "espresso_state_change {[espresso_state_change range 0 end]}\n"
+
 		append espresso_data "espresso_pressure_goal {[espresso_pressure_goal range 0 end]}\n"
 		append espresso_data "espresso_flow_goal {[espresso_flow_goal range 0 end]}\n"
-		append espresso_data "espresso_temperature_goal {[espresso_temperature_goal range 0 end]}\n"		
+		append espresso_data "espresso_temperature_goal {[espresso_temperature_goal range 0 end]}\n"
+
 
 		# format settings nicely so that it is easier to read and parse
 		append espresso_data "settings {\n"
@@ -3148,6 +3158,9 @@ proc format_espresso_for_history {} {
 	        append espresso_data [subst {\t[list $k] [list $v]\n}]
 	    }
 	    append espresso_data "}\n"
+
+		set app_version [package version de1app]
+		append espresso_data "app_version {$app_version}\n"
 
 		return $espresso_data
 	


### PR DESCRIPTION
Add additional variables to espresso log files

As we are no longer just using the App to save, edit and view the shot files
it is time to add the missing variables to shot files.
This includes in this commit:
- step transitions
- resistance
- deltas
As the App might change the way it is calculating things in the future it
is unrealistic for 3rd party devs to reimplement and keep up with all changes.
To easy traceability a app_version field was added on the highest shot file level.

Signed-off-by: Mimoja <git@mimoja.de>


PLEASE MERGE #53 first