### PR TITLE
Uses new global var 'loaded_plugins' to avoid reloading a plugin

### DIFF
--- a/de1plus/plugins.tcl
+++ b/de1plus/plugins.tcl
@@ -61,8 +61,13 @@ proc plugin_preload {plugin} {
 }
 
 proc load_plugin {plugin} {
+	global loaded_plugins
+	if { ![info exists ::loaded_plugins] } { set loaded_plugins {} }
+	if { [lsearch -exact $loaded_plugins $plugin] > -1 } return
+	
 	if {[catch {
         ::plugins::${plugin}::main
+		lappend loaded_plugins $plugin
 	} err] != 0} {
 		catch {
 			# remove from enabled plugins


### PR DESCRIPTION
Change to avoid reloading plugins, I have used a new global var 'loaded_plugins', maybe you prefer a variable in the plugins namespace?