### PR TITLE
Changes in extensions UI. Handle plugins dependence.

### DIFF
--- a/de1plus/plugins/example/plugin.tcl
+++ b/de1plus/plugins/example/plugin.tcl
@@ -18,7 +18,7 @@ proc ::plugins::${plugin_name}::preload {} {
     # Background image and "Done" button
     add_de1_page "$page_name" "settings_message.png" "default"
     add_de1_text $page_name 1280 1310 -text [translate "Done"] -font Helv_10_bold -fill "#fAfBff" -anchor "center"
-	add_de1_button $page_name {say [translate {Done}] $::settings(sound_button_in); fill_extensions_listbox; page_to_show_when_off extensions; set_extensions_scrollbar_dimensions}  980 1210 1580 1410 ""
+	add_de1_button $page_name {say [translate {Done}] $::settings(sound_button_in); page_to_show_when_off extensions}  980 1210 1580 1410 ""
 
     # Headline
     add_de1_text $page_name 1280 300 -text [translate "Example Plugin"] -font Helv_20_bold -width 1200 -fill "#444444" -anchor "center" -justify "center"

--- a/de1plus/plugins/visualizer_upload/plugin.tcl
+++ b/de1plus/plugins/visualizer_upload/plugin.tcl
@@ -18,7 +18,7 @@ proc ::plugins::${plugin_name}::preload {} {
     # Background image and "Done" button
     add_de1_page "$page_name" "settings_message.png" "default"
     add_de1_text $page_name 1280 1310 -text [translate "Done"] -font Helv_10_bold -fill "#fAfBff" -anchor "center"
-    add_de1_button $page_name {say [translate {Done}] $::settings(sound_button_in); save_plugin_settings visualizer_upload;  fill_extensions_listbox; page_to_show_when_off extensions; set_extensions_scrollbar_dimensions}  980 1210 1580 1410 ""
+    add_de1_button $page_name {say [translate {Done}] $::settings(sound_button_in); save_plugin_settings visualizer_upload;  page_to_show_when_off extensions; }  980 1210 1580 1410 ""
 
     # Headline
     add_de1_text $page_name 1280 300 -text [translate "Visualizer Upload"] -font Helv_20_bold -width 1200 -fill "#444444" -anchor "center" -justify "center"


### PR DESCRIPTION
This PR fixes a number of things in the extensions system:

- To manage dependencies between plugins, a plugin may need to force preloading or loading another plugin. In this case, we must ensure that plugins are not preloaded nor loaded more than once. To handle this, I have added variable "plugin_preloaded" in the plugin namespace. "plugin_loaded" already existed but was set after preloading, not after loading. Now both are set in the right places and they are checked before either preloading or loading. NOTE that for loading this does the same as my previous PR (which used a global variable), but this is a better system that should overwrite the previous suggestion.
- Added new utility procs "plugin_available", "plugin_preloaded" and "plugin_loaded".
- Plugins can set the new namespace variable 'name' in their main proc, with a user-friendly name for the plugin. If it is set, it is  then used in the extensions listbox.
- Check the existence of the plugin settings.tdb file before reading it. Some plugins like DGUI don't need a settings file, others like DYE or SDB create it dynamically on the first startup, so the first time they are used the file doesn't exist. This was not raising a runtime error, but an error did appear in the log file, so this eliminates it.
- Removed wrong "$" in proc load_plugin, line "set $::settings(enabled_plugins)"
- The calls to "fill_extensions_listbox" and "set_scrollbar_dimensions" have been encapsulated in the new proc "after_show_extensions", which is then run automatically every time the "extensions" page is shown by adding it to the page context actions. This way, each plugin needs only invoke "page_to_show_when_off extensions" to return control to the extensions page from its settings page. I find this is much cleaner and prevents errors. I have thus remove the call to those 2 functions in plugins "example" and "visualizer_upload".
- Changes to the extensions page UI:
    * Changed the font foreground color of the metadata, to match the standard grey used in the Insight skin.
    * Removed the first line "Configurable: Yes/No", as it is now evident from the appearance or not of the "Settings" button.
    * The "Settings" button is hidden if the plugin is not configurable.
    * Added an empty line between the author email and the plugin description. I think it is more clear visually.
    * Added a space between the settings icon and the "Settings" text. I think it is more clear visually.
    * Friendly plugin names are shown in the listbox whenever the 'name' plugin namespace variable is defined.
    * Changed behaviour of tapping on the extensions listbox. First tap on a plugin selects it and shows its metadata. Subsequent taps on the same plugin toggle its enabled/disabled state. I find this much more intuitive, and makes the "Toggle" button unnecessary, so it has been removed.
    * Reduce a bit the width of the metadata text, so it doesn't overflow the white square.

