### PR TITLE
machine: Complete state and substate arrays

### DIFF
--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -488,6 +488,7 @@ array set ::de1_num_state {
   18 Clean
   19 InBootLoader
   20 AirPurge
+  21 SchedIdle
 }
 
 
@@ -505,7 +506,18 @@ array set ::de1_substate_types {
 	4	"preinfusion"
 	5	"pouring"
 	6	"ending"
+	7	"Steaming"
+	8	"DescaleInit"
+	9	"DescaleFillGroup"
+	10	"DescaleReturn"
+	11	"DescaleGroup"
+	12	"DescaleSteam"
+	13	"CleanInit"
+	14	"CleanFillGroup"
+	15	"CleanSoak"
+	16	"CleanGroup"
 	17  "refill"
+	18	"PausedSteam"
 }
 array set ::de1_substate_types_reversed [reverse_array ::de1_substate_types]
 


### PR DESCRIPTION
After noting that substate 14 was returned with FW 1238 and that `::de1_substate_types()` did not include it, complete the state and substate lists to be consistent with APIDataTypes.hpp

Based on APIDataTypes.hpp

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>