### PR TITLE
Remove obsolete timer

### DIFF
--- a/de1plus/binary.tcl
+++ b/de1plus/binary.tcl
@@ -1333,19 +1333,6 @@ proc bintest2 {} {
 
 }
 
-proc obsolete_get_timer {state substate} {
-
-  set timerkey "$::de1_num_state_reversed($state)-$::de1_substate_types_reversed($substate)"
-  set timer 0
-
-  catch {
-	set timer $::timers($timerkey)
-  }
-
-  #puts "$timerkey - timer $state $substate : $timer [array get ::timers]"
-  return $timer
-}
-
 set ::previous_FrameNumber -1
 proc update_de1_shotvalue {packed} {
 

--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -557,45 +557,6 @@ proc flush_done_timer {} {
 	}
 }
 
-
-proc obsolete_event_timer_calculate {state destination_state previous_states} {
-
-
-
-	set eventtime [get_timer $state $destination_state]
-	 set beforetime 0
-	foreach s $previous_states {
-		set thistime [get_timer $state $s]
-		if {$thistime > $beforetime} {
-			set beforetime $thistime
-		}
-	}
-
-	
-
-	set elapsed [expr {($eventtime - $beforetime)/100}]
-	if {$elapsed < 0} {
-		# this means that the event has not yet started
-		return 0
-	}
-
-	return $elapsed
-}
-
-#proc preinfusion_timer {} {
-#	return [event_timer_calculate "Espresso" "preinfusion" {"stabilising" "final heating" "heating"} ]
-#}
-
-
-#proc pour_timer {} {
-#	return [event_timer_calculate "Espresso" "pouring" {"preinfusion" "stabilising" "final heating" "heating"} ]
-#}
-
-#proc done_timer {} {
-#	return [event_timer_calculate "Idle" "ready" {"pouring" "preinfusion" "stabilising" "final heating" "heating"} ]
-#}
-
-
 proc steam_timer {} {
 zz1
 	return [pour_timer]


### PR DESCRIPTION
Unused and named as obsolete

de1app/de1plus]$ fgrep -r obsolete_ *.tcl skins
binary.tcl:proc obsolete_get_timer {state substate} {
vars.tcl:proc obsolete_event_timer_calculate {state destination_state previous_states} {

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>