### PR TITLE
Add web_api handler to return the DE1 machine state

### DIFF
--- a/de1plus/plugins/web_api/plugin.tcl
+++ b/de1plus/plugins/web_api/plugin.tcl
@@ -89,7 +89,7 @@ proc ::wibble::checkStatus {state} {
     dict set response status 200
     dict set state response header content-type "" {text/plain charset utf-8}
     
-    # Returning a simple text 1 if the machine is in anything other than an idle state. Return text 0 if idle.
+    # Returning a simple text 1 if the machine is in anything other than an sleep state. Return text 0 if sleep.
     # Return values chosen by cribbing from Supereg/homebridge-http-switch
 
     if { $::de1_num_state($::de1(state)) != "Sleep" } {

--- a/de1plus/plugins/web_api/plugin.tcl
+++ b/de1plus/plugins/web_api/plugin.tcl
@@ -81,21 +81,21 @@ proc ::wibble::togglePowerOff {state} {
     sendresponse $response
 }
 
-proc ::wibble:checkStatus {state} {
+proc ::wibble::checkStatus {state} {
     if { ![check_auth $state] } {
         return;
     }
 
     dict set response status 200
-    dict set state response header content-type "" {application/json charset utf-8}
+    dict set state response header content-type "" {text/plain charset utf-8}
     
     # Returning a simple text 1 if the machine is in anything other than an idle state. Return text 0 if idle.
     # Return values chosen by cribbing from Supereg/homebridge-http-switch
 
-    if { $::de1_num_state($::de1(state)) != 0 } {
-        dict set response content "{1}"
+    if { $::de1_num_state != 0 } {
+        dict set response content "1"
     } else {
-        dict set response content "{0}"
+        dict set response content "0"
     }
     
     sendresponse $response

--- a/de1plus/plugins/web_api/plugin.tcl
+++ b/de1plus/plugins/web_api/plugin.tcl
@@ -92,7 +92,7 @@ proc ::wibble::checkStatus {state} {
     # Returning a simple text 1 if the machine is in anything other than an idle state. Return text 0 if idle.
     # Return values chosen by cribbing from Supereg/homebridge-http-switch
 
-    if { $::de1_num_state != 0 } {
+    if { $::de1_num_state($::de1(state)) != "Sleep" } {
         dict set response content "1"
     } else {
         dict set response content "0"


### PR DESCRIPTION
Add checkStatus procedure in web_api extension. I went with a plaint/text return instead of application/json as I just wanted to return a simple 1 or 0 which is what homebridge-http-switch expects.

This is my first time touching TCL so won't be upset if I get yelled at for failing to follow some basic norms. :)