### PR TITLE
Remove overwrite of the wrong widget 'widget_profile_name_to_save'

### DIFF
--- a/de1plus/plugins/visualizer_upload/plugin.tcl
+++ b/de1plus/plugins/visualizer_upload/plugin.tcl
@@ -39,7 +39,6 @@ proc ::plugins::${plugin_name}::preload {} {
     add_de1_text $page_name 280 480 -text [translate "Username"] -font Helv_8 -width 300 -fill "#444444" -anchor "nw" -justify "center"
     # The actual content. Here a list of all settings for this plugin
     add_de1_widget "$page_name" entry 280 540  {
-        set ::globals(widget_profile_name_to_save) $widget
         bind $widget <Return> { say [translate {save}] $::settings(sound_button_in); borg toast [translate "Saved"]; save_plugin_settings visualizer_upload; hide_android_keyboard}
         bind $widget <Leave> hide_android_keyboard
     } -width [expr {int(38 * $::globals(entry_length_multiplier))}] -font Helv_8  -borderwidth 1 -bg #fbfaff  -foreground #4e85f4 -textvariable ::plugins::visualizer_upload::settings(visualizer_username) -relief flat  -highlightthickness 1 -highlightcolor #000000


### PR DESCRIPTION
The removed line of code was overwritting the wrong global variable. It was reassigning the rename-profile widget stored in "widget_profile_name_to_save" to the username widget in the plugin. This means that code in the base app that used that global variable (like proc profile_has_changed_set_colors) was doing the changes to the wrong widget if this plugin was enabled.

Beware that this line of code seems to have slipped by "copy-paste" to other places outside of the main repository, too. I could find instances of it in the MimojaCafe skin and in the keyboard_control plugin. I don't have those repos cloned, so may I please ask @mimoja and @vjapolitzer to look for that line and remove it, or assign $widget to your own widget variable (though that doesn't seem needed as if you had needed the widget reference you would have likely caught the bug).