### PR TITLE
Installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ brew install tcl-tk
 
 Install undroidwish
 1. Download MacOS dmg from: http://www.androwish.org/download/index.html
-2. Double click to install dmg
+2. Click the downloaded dmg to install
 3. Drag `undroidwish` application from the mounted dmg into `Applications` folder
 4. Add `undroidwish` to your path: `sudo ln -s /Applications/undroidwish.app/Contents/MacOS/undroidwish /usr/local/bin/.`
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,28 @@ The `misc` submodule containes scripts and androwish / undroidwish support files
 The `psd` submodule contains the original photoshop files from which the skins and settings pages are generated.
 
 The de1beta folder should ideally be copyable directly to the tablet and run from there. Further testing might be required to test some of the so far unreleased skins.
+
+## Development
+
+### Installation
+
+> The following steps assume you are using MacOS
+
+Install tcl/tk
+```
+brew install tcl-tk
+```
+
+Install undroidwish
+1. Download MacOS dmg from: http://www.androwish.org/download/index.html
+2. Double click to install dmg
+3. Drag `undroidwish` application from the mounted dmg into `Applications` folder
+4. Add `undroidwish` to your path: `sudo ln -s /Applications/undroidwish.app/Contents/MacOS/undroidwish /usr/local/bin/.`
+
+### Running
+
+In the `de1plus` folder there is a shell file: `unde1plus.sh` simply run this in the terminal to start the application:
+
+```
+./de1plus/unde1plus.sh
+```

--- a/de1plus/unde1plus.sh
+++ b/de1plus/unde1plus.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Get the relative path for this script file
 SCRIPT_DIR=$(dirname "$0")
 
 # You should put undroidwish into your path to have this script work

--- a/de1plus/unde1plus.sh
+++ b/de1plus/unde1plus.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SCRIPT_DIR=$(dirname "$0")
+
 # You should put undroidwish into your path to have this script work
 # 
 # On Mac OSX, you can for example do this this:
@@ -8,5 +10,5 @@
 
 #export SDL_VIDEODRIVER=jsmpeg
 #export SDL_VIDEO_JSMPEG_OUTFILE=~/Desktop/decent.mpg
-undroidwish de1plus.tcl  -sdlheight 800 -sdlwidth 1280 -sdlrootheight 800 -sdlrootwidth 1280 -name Decent -sdlresizable
+undroidwish $SCRIPT_DIR/de1plus.tcl  -sdlheight 800 -sdlwidth 1280 -sdlrootheight 800 -sdlrootwidth 1280 -name Decent -sdlresizable
 


### PR DESCRIPTION
Added some documentation for how to setup the application locally in a dev environment. 

### Summary of changes
* Added an `Installation` section to the `README.md` outlining the steps to install on a MacOS environment

* Also added a `SCRIPT_DIR` env var to the `undrowish.sh` file which allows you to run the command from any directory (instead of having to be in `de1plus`)