### PR TITLE
Remove duplicated fast_write_open

### DIFF
--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -2166,14 +2166,6 @@ proc after_shot_weight_hit_update_final_weight {} {
 
 }
 
-proc fast_write_open {fn parms} {
-	set f [open $fn $parms]
-	fconfigure $f -blocking 0
-	fconfigure $f -buffersize 1000000
-	return $f
-}
-
-
 proc scanning_state_text {} {
 	if {$::scanning == 1} {
 		return [translate "Searching"]


### PR DESCRIPTION
As commented on issue #76, I have removed the duplicated version of the fast_write_open proc in bluetooth.tcl (which was the one actually being called when settings were saved), and keep the version on updater.tcl. 

I've had it like that on my dev environment & tablet for a few days without issues, and it has solved the bug of duplicated line endings in settings file on every save under Windows. The differences between the 2 versions were:

- The bluetooth version did not have error catching
- The bluetooth version was non blocking, but as the comment in the code says, apparently it's not needed
- The bluetooth version didn't have end-of-line conversion, which is needed to solve the bug on Windows.