### PR TITLE
Properly reset beverage_type to not persist if undef in new profile

### DIFF
--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -2795,6 +2795,12 @@ proc load_settings_vars {fn} {
 		set temp_settings(final_desired_shot_volume) [ifexists temp_settings(final_desired_shot_weight)]
 	}
 
+	# properly reset beverage_type if not provided in the profile, o/w the beverage_type of the last profile with it
+	#	defined will be persisted throughout all subsequent shots.
+	if { ![info exists temp_settings(beverage_type)] } {
+		set temp_settings(beverage_type) {}
+	}
+		
 	if {[ifexists ::temp_settings(black_screen_saver)] == 1} {
 		# we've moved the "black screen saver" feature from its own dedicated variable to now be a setting of "0 minutes" on the screen saver change timer
 		# this line is simply for backward compatiblity, moving the old setting to a new one


### PR DESCRIPTION
The recently introduced field "beverage_type" was not being properly reset. Because it's a new field that is not set in the GUI, existing user-created profiles usually don't have yet included it. Because everything goes to the settings and persists there forever if not changed (something that produces problems in sooo many ways), this was getting wrong values when a profile was selected that hadn't that field defined.

To reproduce:
- Make a shot using the profile "Forward flush". This modifies the settings with ``beverage_type cleaning``
- Change the profile to a user-created profile that hasn't the field "beverage_type" defined in the <profile>.tcl file
- Make a shot with the new profile.
- The new shot file gets ``beverage_type cleaning`` despite being e.g. an espresso shot.

The field "beverage_type" is used in plugins such as visualizer_upload to prevent uploading cleaning or calibration shots, and was failing in this cases.

The solution is just to detect that the field is not defined in proc ``load_settings_var``, and, in that case, modify its value in the settings to an empty string.

Note that this problem happens exactly the same with any new settings field introduced by skins and plugins. A standard mechanism should be devised to avoid this.