### PR TITLE
Allow de1plus/unde1plus.sh to be launched from anywhere

### DIFF
--- a/de1plus/unde1plus.sh
+++ b/de1plus/unde1plus.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Change working directory for this script to its parent directory so that it
+# can be called from anywhere.
+cd "$(dirname "$0")"
+
 # You should put undroidwish into your path to have this script work
 # 
 # On Mac OSX, you can for example do this this:


### PR DESCRIPTION
Change working directory into the de1plus directory as the first part of the
script so that relative paths to *.tcl files work correctly.