### PR TITLE
de1: Provide SAV for Hot Water

### DIFF
--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -811,6 +811,7 @@ proc start_espresso {} {
 proc reset_gui_starting_hotwater {} {
 	set ::de1(timer) 0
 	set ::de1(volume) 0
+	set ::de1(pour_volume) 0
 	incr ::settings(water_count)
 
 	save_settings


### PR DESCRIPTION
Although HotWater was listed as a tracking state for SAV,
the pour_volume wasn't being set for HotWater.

Reetting of ::de1(pour_volume) is in machine.tcl
consistent with other flow-start initialization
to keep them together in one place for clarity.
Suggest future refactor out of ::reset_gui_starting_*

An unwrapping issue related to the DE1 ShotSample timer
was also corrected. This event occurs roughly every
9 or 11 minutes and would result in "missing" one update,
on the order of 1 ml or less, if it occurred during flow.

SIGNIFICANT END-USER CHANGES
============================

SAV should be usable for hot water, with or without a scale.

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>