### PR TITLE
de1: Fix "negative time" display during some shots

### DIFF
--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -331,6 +331,7 @@ proc stop_espresso_timers {} {
 }
 
 proc start_espresso_timers {} {
+	clear_espresso_timers
 	set ::timer_running 1
 	set ::timers(espresso_start) [clock milliseconds]
 


### PR DESCRIPTION
If a shot was interrupted during PreInfuse, the next shot would render
negative time in the GUI until the shot ended. Once that next shot ended,
the times rendered would be correct.

Traced to ::start_espresso_timers not properly resetting the timers.

Resolved by resetting those timers in that routine, presently in vars.tcl

There still is a behavior where, before flow begins, the times from
the previous shot appear. Changing this would mean that an "aborted"
shot would wipe the previous timers. Deferring any such changes to next
release cycle.

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>