### PR TITLE
de1: Remove duplication of after_flow_complete trigger

### DIFF
--- a/de1plus/binary.tcl
+++ b/de1plus/binary.tcl
@@ -1616,7 +1616,9 @@ proc update_de1_state {statechar} {
 
 	}
 
-	if { $::de1::event::apply::_after_flow_complete_holding_for_idle && $this_flow_phase == "" } {
+	if { $::de1::event::apply::_after_flow_complete_holding_for_idle \
+		     && $::de1::event::apply::_after_flow_complete_after_id == "" \
+		     && $this_flow_phase == "" } {
 
 		# TODO: Decouple this from internal representation
 

--- a/de1plus/de1_de1.tcl
+++ b/de1plus/de1_de1.tcl
@@ -172,6 +172,8 @@ namespace eval ::de1::event::apply {
 
 		# Timer has fired, defer if still in a flow phase (such as "ending")
 
+		set ::de1::event::apply::_after_flow_complete_after_id ""
+
 		# args represent state at time scheduled, not now
 
 		if { ! [::de1::state::is_flow_state [::de1::state::current_state]] } {


### PR DESCRIPTION
Commit 94a0ed00 introduced a case where the after_flow_complete event
was being triggered twice under certain circumstances. This commit
resolves this by checking that there is not a pending timer before
triggering the event.

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>