### PR TITLE
de1: Add SchedIdle to ::de1_state array

### DIFF
--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -484,6 +484,7 @@ array set ::de1_state {
     Clean \x12
     InBootLoader \x13
     AirPurge \x14
+	SchedIdle \x15
 }
 
 


### PR DESCRIPTION
Firmware 1255 and later may utilize SchedIdle (21, 0x15)
state as a request and in its reports.

Extend the ::de1_state array to accomodate.
::de1_num_state already includes an entry.

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>