### PR TITLE
GUI: Allow skins to provide non-resized splash screen

### DIFF
--- a/de1plus/gui.tcl
+++ b/de1plus/gui.tcl
@@ -2053,7 +2053,12 @@ proc update_de1_plus_advanced_explanation_chart { {context {}} } {
 proc setup_images_for_first_page {} {
 	
 	msg "setup_images_for_first_page"
-	set fn [random_splash_file]
+	set fn "[skin_directory]/${::screen_size_width}x${::screen_size_height}/splash.jpg"
+	if {![file exists $fn]} {
+		msg "$fn does not exist. Using default wallpaper"
+		set fn [random_splash_file]
+	}
+	
 	image create photo splash -file $fn 
 	.can create image {0 0} -anchor nw -image splash -tag splash -state normal
 	pack .can


### PR DESCRIPTION
So far skins do not offer a way to provide a custom splash screen.
This PR adds a simple check if the [skin_directory] already contains a
properly sized splash screen. It is not resized if it does not exist
in the proper resolution to not increase the startup time.

Signed-off-by: Mimoja <git@mimoja.de>