### PR TITLE
scale: Remove redundant timer requests from vars.tcl

### DIFF
--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -326,16 +326,12 @@ proc stop_espresso_timers {} {
 	#msg "stop_timers"
 	set ::timer_running 0
 	set ::timers(espresso_stop) [clock milliseconds]
-
-	scale_timer_stop
 }
 
 proc start_espresso_timers {} {
 	clear_espresso_timers
 	set ::timer_running 1
 	set ::timers(espresso_start) [clock milliseconds]
-
-	scale_timer_start
 }
 
 proc clear_espresso_timers {} {


### PR DESCRIPTION
The scale's timer is now managed on events. Remove the now-redundant,
hard-coded calls to start and stop it in vars.tcl.

Felicita scales are presently the only scales with a visible timer.

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>