### PR TITLE
Revert "don't need to give an ENJOY message..."

### DIFF
--- a/de1plus/gui.tcl
+++ b/de1plus/gui.tcl
@@ -3055,10 +3055,9 @@ namespace eval ::gui::notify {
 			}
 
 			record_complete {
-				# don't need to give an ENJOY message when the app already gives "stopped on volume, stopped on weight" messages just a few seconds earlier.
-				#set what [translate {Enjoy!}]
-				#borg toast $what
-				#say $what $::settings(sound_button_in)
+				set what [translate {Enjoy!}]
+				borg toast $what
+				say $what $::settings(sound_button_in)
 			}
 
 			saw_stop {


### PR DESCRIPTION
Contrary to the justification given for removal of the "Enjoy!"
message in commit caacd68, it indicates recording complete,
which is an important and distinct step in the sequence of a shot.

Further, the SAW or SAV messages ("Stopping for weight/volume") only
are presented when one of those two processes trigger. They are not
presented when a shot completes as it "walks off the end" of the steps.

This restores the intended, default behavior where the completion of
the shot is always indicated to the operator both visually and, for
users that rely on audio cues, wth "speak". By also indicting to the
user when SAV or SAW is triggered (visual only, as it is secondary
data) a user can now clearly distinguish between:

  * Shot terminated due to SAV
  * Shot terminated due to SAW
  * Shot terminated by the DE1 (likely end of profile)

This behavior resolved the long-standing complaints around the
messages in v1.34 and earlier being incorrect and improperly
indicating "weight reached" when SAW was not triggered.

Should an individual wish to remove or change the indication of this
important event on a shot's timeline, it can be overriden by a skin
or in an extension.

This reverts commit caacd68.

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>