### PR TITLE
scale: Remove redundant scale-timer reset from vars.tcl

### DIFF
--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -351,10 +351,6 @@ proc clear_espresso_timers {} {
 	set ::timers(espresso_pour_stop) 0
 
 	set ::timer_running 0
-
-	catch {
-		scale_timer_reset
-	}
 }
 
 clear_espresso_timers


### PR DESCRIPTION
_**Waiting for feedback from impacted user(s). Thread on DD open.**_

_No negative feedback received. Opening for adoption._

_**Testing with any forthcoming scales prior to merge would also be valuable.**_ (Hint: @decentjohn )

_These changes can be tested out on "any" current build with the plugin available on that thread._

Scales that have a timer and have ::device::scale::use_timer True
will have their timer reset on entering a flow state, such as Espresso.

Code in vars.tcl would also call ::scale_timer_reset on resetting the
espresso timers, typically at the start of flow.

At the start of flow, a timer-start command is sent. This often
immediately after the timer-clear command from vars.tcl. There is some
evidence that scale hardware may not gracefully handle tight timing.

Rather than introduce a delay, remove the redundant call in vars.tcl

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>