### PR TITLE
Add local_time to .shot file

### DIFF
--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -2957,6 +2957,7 @@ proc format_espresso_for_history {} {
 		set espresso_data {}
 		set espresso_data "name [list $name]\n"
 		set espresso_data "clock $clock\n"
+		append espresso_data "local_time {[clock format $clock]}\n"
 		#set espresso_data "final_espresso_weight $::de1(final_espresso_weight)\n"
 
 		#set espresso_data "settings [array get ::settings]\n"


### PR DESCRIPTION
The .shot file presently only contains a timestamp in seconds without
timezone.  Uploaded .shot files, such as from an extension, may no
longer have their name to assist in cross-referencing with the logs.

Add local_time as the line after "clock" at the top of the .shot file.

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>