### PR TITLE
Solve bug with $::all_labels in proc page_display_change

### DIFF
--- a/de1plus/gui.tcl
+++ b/de1plus/gui.tcl
@@ -1498,6 +1498,26 @@ proc page_display_change {page_to_hide page_to_show} {
 
 	}
 
+
+	#msg "these_labels: $these_labels"
+
+#	if {[info exists ::all_labels] != 1} {
+#		set ::all_labels {}
+#		foreach {page labels} [array get ::existing_labels]  {
+#			set ::all_labels [concat $::all_labels $labels]
+#		}
+#		set ::all_labels [lsort -unique $::all_labels]
+#	}
+#
+#	#msg "Hiding [llength $::all_labels] labels"
+#	foreach label $::all_labels {
+#		if {[.can itemcget $label -state] != "hidden"} {
+#			.can itemconfigure $label -state hidden
+#			#msg "hiding: '$label'"
+#		}
+#	}
+	.can itemconfigure all -state hidden
+
 	set errcode [catch {
 		.can itemconfigure $page_to_show -state normal
 	}]
@@ -1508,27 +1528,9 @@ proc page_display_change {page_to_hide page_to_show} {
 		}
 
 	} 
-
-	set these_labels [ifexists ::existing_labels($page_to_show)]
-	#msg "these_labels: $these_labels"
-
-	if {[info exists ::all_labels] != 1} {
-		set ::all_labels {}
-		foreach {page labels} [array get ::existing_labels]  {
-			set ::all_labels [concat $::all_labels $labels]
-		}
-		set ::all_labels [lsort -unique $::all_labels]
-	}
-
-	#msg "Hiding [llength $::all_labels] labels"
-	foreach label $::all_labels {
-		if {[.can itemcget $label -state] != "hidden"} {
-			.can itemconfigure $label -state hidden
-			#msg "hiding: '$label'"
-		}
-	}
-
+	
 	#msg "Showing [llength $these_labels] labels"
+	set these_labels [ifexists ::existing_labels($page_to_show)]	
 	foreach label $these_labels {
 		.can itemconfigure $label -state normal
 		#msg "showing: '$label'"


### PR DESCRIPTION
This should solve a long-time bug that made that pages that were added "late" (i.e. not during startup) didn't have their canvas items correctly hidden. It was also not hidden the visualizer_upload setting page controls when leaving the page after recent changes on the plugin.

The reason is that the global variable used to know which labels to hide was $::all_labels, and it was being constructed in proc page_display_change only ONCE, and never updated. So, after page_display_change was run once, new pages (or new items added to existing pages) were not shown correctly but not hidden properly.

Updating $::all_labels on every page_display_change slows down things, so to solve this I've completely ditched the $::all_labels system, and used instead the solution I'm applying on the forthcoming DUI: Hide everything with the one-liner ".can itemconfigure all -state hidden", then show the new page items. $::all_labels is no longer needed.
