### PR TITLE
Improve web_api plugin

### DIFF
--- a/de1plus/plugins/web_api/plugin.tcl
+++ b/de1plus/plugins/web_api/plugin.tcl
@@ -126,7 +126,7 @@ namespace eval ::plugins::${plugin_name} {
         # Start a server and enter the event loop if not already there.
 
         catch {
-            ::wibble::listen 8080
+		::wibble::listen $::plugins::web_api::settings(webserver_port)
         }
 
 	}  ;# main

--- a/de1plus/plugins/web_api/plugin.tcl
+++ b/de1plus/plugins/web_api/plugin.tcl
@@ -99,6 +99,16 @@ namespace eval ::plugins::${plugin_name} {
 		::wibble::return_200_json
 	}
 
+	proc ::wibble::flushLog {state} {
+		if { ![check_auth $state] } {
+			return;
+		}
+
+		::logging::flush_log
+
+		::wibble::return_200_json
+	}
+
 	proc ::wibble::checkStatus {state} {
 		if { ![check_auth $state] } {
 			return;
@@ -120,7 +130,8 @@ namespace eval ::plugins::${plugin_name} {
 
         ::wibble::handle /on togglePowerOn
         ::wibble::handle /off togglePowerOff
-        ::wibble::handle /status checkStatus
+	::wibble::handle /status checkStatus
+	::wibble::handle /flush flushLog
         ::wibble::handle / notfound
 
         # Start a server and enter the event loop if not already there.

--- a/de1plus/plugins/web_api/plugin.tcl
+++ b/de1plus/plugins/web_api/plugin.tcl
@@ -2,7 +2,6 @@ package require de1_machine
 
 set plugin_name "web_api"
 
-namespace eval ::wibble {}
 namespace eval ::plugins::${plugin_name} {
 
     variable author "Johanna Schander"
@@ -34,84 +33,101 @@ namespace eval ::plugins::${plugin_name} {
             after 2000 [list info_page [translate "Please change the Webserver auth key!"] [translate "Ok"]]
             return
         }
-        # Define handlers
+
+	# Auth
+
+	proc ::wibble::check_auth {state} {
+		set auth [dict getnull $state request query auth]
+		set auth [lindex $auth 1]
+
+		if {$auth eq ""} {
+			return [unauthorized $state]
+		}
+
+		if {$auth != $::plugins::web_api::settings(webserver_authentication_key)} {
+			return [unauthorized $state]
+		}
+
+		return true;
+	}
+
+	proc ::wibble::unauthorized {state} {
+		dict set response status 403
+		dict set state response header content-type "" {application/json charset utf-8}
+		dict set response content "{status: \"unauthorized\"}"
+		sendresponse $response
+		return false;
+	}
+
+	# Utilities
+
+	proc ::wibble::return_200_json {{content "{status: ok}"}} {
+
+		dict set response status 200
+		dict set state response header content-type "" {application/json charset utf-8}
+		dict set response content "$content"
+		sendresponse $response
+	}
+
+	proc ::wibble::return_200_text {{content "ok"}} {
+
+		dict set response status 200
+		dict set state response header content-type "" {text/plain charset utf-8}
+		dict set response content "$content"
+		sendresponse $response
+	}
+
+	# Actions
+
+	proc ::wibble::togglePowerOn {state} {
+		if { ![check_auth $state] } {
+			return;
+		}
+
+		start_idle
+
+		::wibble::return_200_json
+	}
+
+	proc ::wibble::togglePowerOff {state} {
+		if { ![check_auth $state] } {
+			return;
+		}
+
+		start_sleep
+
+		::wibble::return_200_json
+	}
+
+	proc ::wibble::checkStatus {state} {
+		if { ![check_auth $state] } {
+			return;
+		}
+
+		# Returning a simple text 1 if the machine is in anything other than an sleep state. Return text 0 if sleep.
+		# Return values chosen by cribbing from Supereg/homebridge-http-switch
+
+		if { $::de1_num_state($::de1(state)) != "Sleep" } {
+			set not_sleep "1"
+		} else {
+			set not_sleep "0"
+		}
+
+		::wibble::return_200_text $not_sleep
+	}
+
+	# Define handlers
+
         ::wibble::handle /on togglePowerOn
         ::wibble::handle /off togglePowerOff
         ::wibble::handle /status checkStatus
         ::wibble::handle / notfound
 
         # Start a server and enter the event loop if not already there.
+
         catch {
             ::wibble::listen 8080
         }
-    }
-}
-proc ::wibble::check_auth {state} {
-    set auth [dict getnull $state request query auth]
-    set auth [lindex $auth 1]
 
-    if {$auth eq ""} {
-        return [unauthorized $state]
-    }
-
-    if {$auth != $::plugins::web_api::settings(webserver_authentication_key)} {
-        return [unauthorized $state]
-    }
-
-    return true;
-}
-
-proc ::wibble::unauthorized {state} {
-    dict set response status 403
-    dict set state response header content-type "" {application/json charset utf-8}
-    dict set response content "{status: \"unauthorized\"}"
-    sendresponse $response
-    return false;
-}
-
-
-proc ::wibble::togglePowerOn {state} {
-    if { ![check_auth $state] } {
-        return;
-    }
-
-    start_idle
-
-    dict set response status 200
-    dict set state response header content-type "" {application/json charset utf-8}
-    dict set response content "{status: \"ok\"}"
-    sendresponse $response
-}
-
-proc ::wibble::togglePowerOff {state} {
-    if { ![check_auth $state] } {
-        return;
-    }
-    
-    start_sleep
-
-    dict set response status 200
-    dict set state response header content-type "" {application/json charset utf-8}
-    dict set response content "{status: \"ok\"}"
-    sendresponse $response
-}
-
-proc ::wibble::checkStatus {state} {
-    if { ![check_auth $state] } {
-        return;
-    }
-
-    dict set response status 200
-    dict set state response header content-type "" {text/plain charset utf-8}
-    
-    # Returning a simple text 1 if the machine is in anything other than an sleep state. Return text 0 if sleep.
-    # Return values chosen by cribbing from Supereg/homebridge-http-switch
-
-    if { $::de1_num_state($::de1(state)) != "Sleep" } {
-        dict set response content "1"
-    } else {
-        dict set response content "0"
-    }
-    
-    sendresponse $response
+	}  ;# main
 }


### PR DESCRIPTION
**This is not a priority for v1.35**

As noted in #73 the web_api plugin previously created and used the `::wibble` namespace, even if the plugin was not enabled. Resolved by moving the `proc ::wibble::*` definitions into `main {}`

Seeing duplication of the generation the response object and expecting to add to the API, made generalized "200"  returns for JSON and text data.

In resolving that, noted that the port was hard-coded.

Added a /flush action, which calls `::logging::flush_log` (Introduced by #114, not merged at this time).
