### PR TITLE
de1: Handle heater voltage being an empty string

### DIFF
--- a/de1plus/de1_de1.tcl
+++ b/de1plus/de1_de1.tcl
@@ -230,7 +230,11 @@ namespace eval ::de1 {
 
 	proc line_voltage_nom {} {
 
-		if {[info exists ::settings(heater_voltage)]} {
+		# string is double "" returns 1, expr {double("")} is an error
+
+		if {[info exists ::settings(heater_voltage)] \
+			    && [string is double $::settings(heater_voltage)] \
+			    && $::settings(heater_voltage) != "" } {
 			return [expr { double($::settings(heater_voltage)) }]
 		} else {
 			return False


### PR DESCRIPTION
A newly connected DE1 may not yet have been queried for its line
voltage when frequency estimation begins. Although
::settings(heater_voltage) exists, it may be an empty string.

Resolve by returning False as is already the case when undefined.

Note the Tcl inconsistency behing the logic:

    % set n ""
    % string is double $n
    1
    % expr { double($n) }
    expected floating-point number but got ""

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>