### PR TITLE
de1: Protect against unrecognized states and substates

### DIFF
--- a/de1plus/de1_de1.tcl
+++ b/de1plus/de1_de1.tcl
@@ -421,12 +421,20 @@ namespace eval ::de1::state {
 
 	proc current_state {} {
 
-		expr { $::de1_num_state($::de1(state)) }
+	    try { set state_text [expr { $::de1_num_state($::de1(state)) }] } on error result {
+		set state_text [format "unknown_0x%02x" $::de1(state)]
+		msg -ERROR [format "Unrecognized API_MachineStates 0x%02x" $::de1(state)]
+	    }
+	    return $state_text
 	}
 
 	proc current_substate {} {
 
-		expr { $::de1_substate_types($::de1(substate)) }
+	    try { set substate_text [expr { $::de1_substate_types($::de1(substate)) }] } on error result {
+		set substate_text [format "unknown_0x%02x" $::de1(substate)]
+		msg -ERROR [format "Unrecognized API_Substates 0x%02x" $::de1(substate)]
+	    }
+	    return $substate_text
 	}
 
 	proc is_flow_state {{state_text "None"} {substate_text "None"}} {


### PR DESCRIPTION
User reported a condition where, when using a refill kit, after
starting the DE1 but before the tray had been filled, a substate of
decimal 20 was reported. As this is not in the arrays in machine.tcl,
an error occurred. As the current state and substate are often checked
on each screen refresh, the GUI became non-responsive.

Provide a mitigating fix by capturing and logging the lookup failure.
As the substate is not known to the app or skin code, this should not
impact any exisitng functionality.

suggest backport to stable.

Resolve further in the future with updates to machine.tcl for any
known-missing states and substates.

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>