### PR TITLE
Utilize the build-info file in the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ _$*
 core
 # CVS default ignores end
 
+/de1plus/build-info
+
 release
 de1plus/plugins/visualizer_upload/settings.tdb
 de1plus/plugins/web_api/settings.tdb

--- a/de1plus/de1app.tcl
+++ b/de1plus/de1app.tcl
@@ -18,6 +18,93 @@ try {
 	exit
 }
 
+#
+# Inline for now, then move out
+#
+
+namespace eval ::app {
+
+	variable build_info_filename "build-info"
+	variable build_info
+	set build_info [dict create]
+
+	variable build_string ""
+	variable build_timestamp 0
+
+	proc load_build_info {} {
+
+		variable build_info_filename
+		variable build_info
+
+		if { [file readable $build_info_filename] } {
+
+			set _fh [open $build_info_filename "r"]
+
+			foreach _line [split [read $_fh] "\n"] {
+
+				msg -NOTICE "build-info: $_line"
+
+				if { [string length $_line] == 0 } { continue }
+				if { [regexp {^[:space:]*#} $_line] } { continue }
+
+				set _kv [split $_line "\t"]
+				set _k [lindex $_kv 0]
+				if { [llength $_kv] == 1 } {
+					set _v ""
+				} else {
+					set _v [join [lrange $_kv 1 end] "\t"]
+				}
+
+				dict append build_info $_k $_v
+			}
+		} else {
+
+			msg -WARNING "build-info: No such file:" \
+				$build_info_filename
+		}
+	}
+
+	proc ensure_build_strings {} {
+
+		if { [dict exists $::app::build_info version_string] } {
+			set ::app::version_string [dict get $::app::build_info version_string]
+		} else {
+			set ::app::version_string [package version de1app]
+		}
+
+		if { [dict exists $::app::build_info build_timestamp] } {
+
+			set ::app::build_timestamp [dict get $::app::build_info build_timestamp]
+
+		} elseif { [file readable "[homedir]/timestamp.txt"] } {
+
+			set _fh [open "[homedir]/timestamp.txt" "r"]
+
+			set ::app::build_timestamp [string trim [read $_fh]]
+
+		} else {
+
+			set ::app::build_timestamp 0
+		}
+
+		# Use modified ISO 8601 (no T, add space before zone)
+
+		if { $::app::build_timestamp } {
+			set ::app::build_time_string [clock format $::app::build_timestamp \
+							      -format "%Y-%m-%d %H:%M:%S %z"]
+		} else {
+			set ::app::build_time_string [translate "Unknown"]
+		}
+	}
+
+}
+
+::app::load_build_info
+::app::ensure_build_strings
+
+msg -INFO "version_string: $::app::version_string"
+msg -INFO "build time: $::app::build_time_string"
+
 try {
 	de1_ui_startup
 } on error {result ropts} {

--- a/de1plus/misc.tcl
+++ b/de1plus/misc.tcl
@@ -141,6 +141,8 @@ proc make_de1_dir {srcdir destdirs} {
         device_scale.tcl *
         event.tcl *
 
+	build-info *
+
         profiles_v2/readme.txt *
 
         history/info.txt *


### PR DESCRIPTION
Ref: https://github.com/decentespresso/de1plus_misc/pull/2

_**This should get a version version bump for `de1app.tcl` and be reflected in `skins/default/de1_skin_settings.tcl`**_

Read in the build-info file if present, log it at the top of the log (so logs uploaded always have detailed app-version information).

Provide programmatic access to the build-info contents.

~~Use the more-detailed string in the GUI~~

**No GUI changes**