### PR TITLE
app: Log tcl_patchLevel, warn if running 8.6.10 (AndroWish 2020)

### DIFF
--- a/de1plus/main.tcl
+++ b/de1plus/main.tcl
@@ -28,8 +28,16 @@ package require http 2.5
 ##############################
 
 proc de1_ui_startup {} {
-	cd [homedir]
-	return [ui_startup]
+
+    cd [homedir]
+
+    msg -INFO "Tcl version $::tcl_patchLevel"
+    # There are multiple reports of AndroWish 2020-11-05 causing crashes in early 2021
+    if { $::tcl_patchLevel == "8.6.10" } {
+	msg -WARNING "AndroWish 2020-11-05 is not recommended at this time. 2019-06-22 (8.6.9) is preferred."
+    }
+
+    return [ui_startup]
 }
 
 


### PR DESCRIPTION
Multiple users have reported instability when running AndroWish 2020-11-05
("The Flux Capacitor").

Log the tcl patch level and warn if 8.6.10, corresponding to AndroWish 2020,
along with a recommendation to use the 2019 version.

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>