### PR TITLE
gui: Suppress scale disconnect messages when DE1 is in Sleep

### DIFF
--- a/de1plus/gui.tcl
+++ b/de1plus/gui.tcl
@@ -3013,9 +3013,16 @@ namespace eval ::gui::notify {
 
 			not_connected {
 
-				set what [translate {WARNING: Scale not connected}]
-				borg toast $what
-				say $what $::settings(sound_button_in)
+			    # With automatically_ble_reconnect_forever_to_scale 1
+			    # `ble` will report a connection event when attempting to connect.
+			    # When the connection fails, the disconnect logic fires.
+			    # This has been reported to cause "ticking" sounds every 30 seconds.
+
+			    if { [::de1::state::current_state] == "Sleep" } { return }
+
+			    set what [translate {WARNING: Scale not connected}]
+			    borg toast $what
+			    say $what $::settings(sound_button_in)
 			}
 
 			no_updates {


### PR DESCRIPTION
User reported that every 30 seconds, evne when sleeping, the toast
"Warning: Scale not connected" is displayed, along with a ticking sound.

This can be replicated by configuring a scale, turning it off, and setting
automatically_ble_reconnect_forever_to_scale 1

It is due to the `ble` stack sending a connection event as it starts
to try to connenct by address and then a disconnect event when it fails.

Gate the message so it is not displayed when the DE1 is in Sleep
state.

Long-term resolution is a BLE stack that properly reports
connection state.

Resolves https://github.com/decentespresso/de1app/issues/129

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>