### PR TITLE
shot: Fix misspelling of "translate"

### DIFF
--- a/de1plus/shot.tcl
+++ b/de1plus/shot.tcl
@@ -300,7 +300,7 @@ namespace eval ::shot {
     proc convert_all_legacy_to_v2 {} {
         set dirs [lsort -dictionary [glob -nocomplain -tails -directory "[homedir]/history/" *.shot]]
 
-        boarg toast [tranlate "Converting old shot files"]
+        borg toast [translate "Converting old shot files"]
 
         blt::vector create espresso_elapsed god_espresso_elapsed god_espresso_pressure steam_pressure steam_temperature steam_flow steam_elapsed espresso_pressure espresso_flow god_espresso_flow espresso_flow_weight god_espresso_flow_weight espresso_flow_weight_2x god_espresso_flow_weight_2x espresso_flow_2x god_espresso_flow_2x espresso_flow_delta espresso_pressure_delta espresso_temperature_mix espresso_temperature_basket god_espresso_temperature_basket espresso_state_change espresso_pressure_goal espresso_flow_goal espresso_flow_goal_2x espresso_temperature_goal espresso_weight espresso_weight_chartable espresso_resistance_weight espresso_resistance
         blt::vector create espresso_de1_explanation_chart_pressure espresso_de1_explanation_chart_flow espresso_de1_explanation_chart_elapsed espresso_de1_explanation_chart_elapsed_flow espresso_water_dispensed espresso_flow_weight_raw espresso_de1_explanation_chart_temperature  espresso_de1_explanation_chart_temperature_10 espresso_de1_explanation_chart_selected_step


### PR DESCRIPTION
Typos in commit 3998a050f resulted in errors.

Corrected spelling of "translate" and "borg"
