### PR TITLE
Don't change the theme in history viewer

### DIFF
--- a/de1plus/history_viewer.tcl
+++ b/de1plus/history_viewer.tcl
@@ -72,9 +72,6 @@ namespace eval ::history_viewer {
 				variable widgets
 				set page [namespace tail [namespace current]]
 
-				set current_theme [dui theme get]
-				dui theme set default
-
 				dui add listbox $page 40   1000 -tags history_left  -canvas_width 450 -canvas_height 550 -yscrollbar yes -font_size -1 -listvariable history_entries
 				dui add listbox $page 1940 1000 -tags history_right -canvas_width 450 -canvas_height 550 -yscrollbar yes -font_size -1 -listvariable history_entries
 


### PR DESCRIPTION
The history viewer setup method was resetting the current theme to the default one and not setting it back, whereas it should not touch the theme.

This was copied from the pages integrated in DUI like dui_number_editor, that change temporarilly the theme to default for setting up the page because they must match the aspect of the settings pages (default/Insight) and then set it back to the current skin theme at the end, but it is not needed in history_viewer, which must rather integrate with the skin theme. This had the side effect of altering how some plugin pages rendered under skins different than Insight.