### PR TITLE
Corrected name of half-star symbol, for draters

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -6602,7 +6602,7 @@ namespace eval ::dui {
 				if { [dui symbol exists "half_$symbol"] } {
 					set half_symbol [dui symbol get "half_$symbol"]
 				} else {
-					set half_symbol [dui symbol get half-star]
+					set half_symbol [dui symbol get star-half]
 				}
 			}		
 			if { [dui symbol exists $symbol] } {


### PR DESCRIPTION
The name of the half-star symbol (e.g. for rating enjoyment) was wrong