### PR TITLE
bluetooth: Resolve Error: invalid command name "2a80"

### DIFF
--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -1892,7 +1892,7 @@ proc de1_ble_handler { event data } {
 									    "of DE1: '$value_for_log'"
 								}
 							} elseif {$address == $::settings(scale_bluetooth_address)} {
-							    ::bt::msg -INFO "ACK wrote to"
+							    ::bt::msg -INFO "ACK wrote to" \
 							    [::logging::short_ble_uuid $cuuid] \
 								    "of $::settings(scale_type): '$value_for_log'"
 							} else {


### PR DESCRIPTION
**I do not have an Acaia scale so I can not test this code path.**

_While believed correct, confirmation would be appreciated._

Add missing line-continuation \ for non-Skale path.

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>