### PR TITLE
New dui subensemble 'dui image'

### DIFF
--- a/de1plus/utils.tcl
+++ b/de1plus/utils.tcl
@@ -17,7 +17,7 @@ proc setup_environment {} {
 	}
 	dui config language [language]
 	dui font add_dirs "[homedir]/fonts/"
-	dui item add_image_dirs "[homedir]/skins/default/"
+	dui image add_dirs "[homedir]/skins/default/"
 	dui sound set button_in "[homedir]/sounds/KeypressStandard_120.ogg" \
 		button_out "[homedir]/sounds/KeypressDelete_120.ogg" \
 		page_change "[homedir]/sounds/KeypressDelete_120.ogg"
@@ -41,7 +41,7 @@ proc setup_environment {} {
 	set ::screen_size_height [dui cget screen_size_height]
 	if { $settings(screen_size_width) != $::screen_size_width || $settings(screen_size_height) != $::screen_size_height } {
 		set settings(screen_size_width) $::screen_size_width
-		set settings(screen_size_height)) $::screen_size_height
+		set settings(screen_size_height) $::screen_size_height
 		save_settings
 #	}
 


### PR DESCRIPTION
Image commands in DUI are now grouped under the subensemble namespace 'dui image':
- New commands 'dui image dirs', 'dui image add_dirs', 'dui image add', 'dui image find' and 'dui image photoscale'
- Resize images dynamically if needed on 'dui add image'
- De-hardcode the base screen size 2560x1800 everywhere.
- When resizing PNG files, now transparent background is preserved.
- Don't fail if an image file is not found, just warn in the log.
 
In addition, I made the following changes:

- Add DUI & platform data to the log on init to facilitate debugging.
- Fix bug introduced by first version of DUI, which was storing in the settings the variable "screen_size_height)"
- Make sound_name in 'dui say' optional.
-