### PR TITLE
de1: scale: Track Bluetooth connectivity state better

### DIFF
--- a/de1plus/de1_de1.tcl
+++ b/de1plus/de1_de1.tcl
@@ -228,6 +228,14 @@ namespace eval ::de1 {
 
 	::de1::event::listener::on_connect_add [lambda {args} ::de1::init]
 
+
+	variable _is_connected False
+
+	proc is_connected {} {
+	    return $::de1::_is_connected
+	}
+
+
 	proc line_voltage_nom {} {
 
 		# string is double "" returns 1, expr {double("")} is an error

--- a/de1plus/device_scale.tcl
+++ b/de1plus/device_scale.tcl
@@ -115,8 +115,6 @@ namespace eval ::device::scale {
 	variable _delayed_tare_id ""
 
 
-
-
 	# See also on_connect callbacks for initialization
 
 	proc init {} {
@@ -126,8 +124,10 @@ namespace eval ::device::scale {
 	}
 
 
+	variable _is_connected False
+
 	proc is_connected {} {
-		expr { [info exists ::de1(scale_device_handle)] == 1  &&  $::de1(scale_device_handle) != 0 }
+	    return $::device::scale::_is_connected
 	}
 
 	proc bluetooth_address {}  {


### PR DESCRIPTION
Only consider the DE1 or the scale to be "connected"
if discovery has been completed.

Note that this ia a change from all prior code where the presence
of a handle from `ble` indicated "connected". This handle would be
present during connect-by-address attempts, even if they failed to
find the device.

Only fire on_disconnect events if the DE1/scale was connected,
using the newly implemented definition.

Adds ::de1::is_connected predicate

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>