### PR TITLE
de1_comms: Don't log when no "stale" items were pruned

### DIFF
--- a/de1plus/de1_comms.tcl
+++ b/de1plus/de1_comms.tcl
@@ -1209,9 +1209,6 @@ proc remove_matching_ble_queue_entries {comment_regexp} {
 				   $comment_regexp \
 				   $old_length $new_length \
 				   [expr {$old_length - $new_length}]]
-	} else {
-		::comms::msg -DEBUG [format "ble_queue: No stale '%s' on queue; %d" \
-				     $comment_regexp $new_length]
 	}
 
 	set ::de1(cmdstack) $new_stack


### PR DESCRIPTION
commit 69f8968a provided functionality that prunes settings and shot
data that is about to be overwritten from the BLE queue.

Now that this seems stable and reliable, only log when items are
removed, omitting the "ble_queue: No stale '%s' on queue; %d"
message at DEBUG level.

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>