### PR TITLE
Prevent widgets unhide in wrong page

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -4297,7 +4297,10 @@ namespace eval ::dui {
 					if { $::android == 1 && [dui cget use_finger_down_for_tap] } {
 						if { [$can type $item] eq "window" } {
 							$can itemconfigure $item -state disabled
-							after 400 $can itemconfigure $item -state normal
+							if { $state eq "normal" } {
+								# Do NOT just show the items. We need to check we're still in the same page after the 400 ms
+								after 400 dui::item::show $page_to_show $item 1
+							}
 						} else {
 							$can itemconfigure $item -state $state
 						}

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -4698,19 +4698,14 @@ namespace eval ::dui {
 		}
 		
 		# "Smart" widgets shower or hider. 'show' can take any value equivalent to boolean (1, true, yes, etc.)
-		# If check_context=1, only hides or shows if the items page is the currently active page. This is useful,
+		# If check_page=1, only hides or shows if the items page is the currently active page. This is useful,
 		#	for example, if you're showing after a delay, as the page/page may have been changed in between.
-		proc show_or_hide { show page_or_ids_or_widgets {tags {}} { check_context 1 } } {
-			if { $tags eq "" && [llength $page_or_ids_or_widgets] == 1 && [dui page exists $page_or_ids_or_widgets] && $check_context } {
+		proc show_or_hide { show page_or_ids_or_widgets {tags {}} { check_page 1 } } {
+			if { $tags eq "" && [llength $page_or_ids_or_widgets] == 1 && [dui page exists $page_or_ids_or_widgets] && $check_page } {
 				if { $page_or_ids_or_widgets ne [dui page current] } {
 					return
 				}
 			}
-#			if { $page eq "" } {
-#				set page [dui page current]
-#			} elseif { $check_context && $page ne [dui page current] } {
-#				return
-#			}
 			
 			if { [string is true $show] || $show eq "show" } {
 				set state normal
@@ -4718,19 +4713,17 @@ namespace eval ::dui {
 				set state hidden
 			}
 			
-			#set ids [get $page_or_ids_or_widgets $tags]
 			foreach id [get $page_or_ids_or_widgets $tags] {
 				[dui canvas] itemconfigure $id -state $state
 			}
-			#config $page_or_ids_or_widgets $tags -state $state
 		}
 		
-		proc show { page tags { check_context 1} } {
-			show_or_hide 1 $page $tags $check_context
+		proc show { page tags { check_page 1} } {
+			show_or_hide 1 $page $tags $check_page
 		}
 		
-		proc hide { page tags { check_context 1} } {
-			show_or_hide 0 $page $tags $check_context
+		proc hide { page tags { check_page 1} } {
+			show_or_hide 0 $page $tags $check_page
 		}
 
 		proc add_image_dirs { args } {


### PR DESCRIPTION
This corrects a bug in the nightly branch introduced by DUI. When fast_tap_mode=0 widgets were initially shown disabled for 400 ms to capture "phantom taps" that persisted through page changes, and enabled after that time. If the user swapped pages fast, they widgets could appear (wrongly) in the new page. So now it is verified that the app is still in the same page before setting the widgets state to normal. Also they are kept disabled if they were created with -initial_state disabled.

In addition, item hiding functions that still had arguments with "context" in their names have had the argument renamed, from "context" to "page", which is the correct term in DUI.