### PR TITLE
Include DE1 Error States in Decode, Pop Error Dialog if DE1 Reports Error

### DIFF
--- a/de1plus/binary.tcl
+++ b/de1plus/binary.tcl
@@ -1328,6 +1328,19 @@ proc update_de1_state {state_info_bin} {
 
 	binary scan $state_info_bin "cucu" _state _substate
 
+	#
+	# Shutdown DE1 communication on error
+	# It is unlikely responding at all and in "protection mode"
+	#
+
+	if { $_state == 11 || $_substate >= 200 } {
+
+	    ::de1::emergency_shutdown
+	    msg -CRITICAL "DE1 EMERGENCY SHUTDOWN triggered by StateInfo:" \
+		    [::logging::format_asc_bin $state_info_bin]
+
+	}
+
 	set _decoded True
 
 	try { set this_state $::de1_num_state($_state) } on error result {
@@ -1357,12 +1370,10 @@ proc update_de1_state {state_info_bin} {
 	# In any event, catch both the FatalError state and any failures to decode
 	# and call ::gui::notify::de1_event
 	#
-	# TODO: Decide if a "hard stop" is appropriate on DE1 error in core
-	#
 
 	if { $this_state == "FatalError" } {
 
-	    msg -CRITICAL [format "DE1 FatalError reported as state %s,%s" \
+	    msg -CRITICAL [format "DE1 FatalError reported as state %s, %s" \
 				   $this_state $this_substate]
 
 	    ::gui::notify::de1_event fatal_error \

--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -1178,6 +1178,8 @@ proc later_new_de1_connection_setup {} {
 
 proc de1_ble {action command_name {data ""}} {
 
+	if { $::de1::_emergency_shutdown } { return }
+
 	if {[ifexists ::sinstance($::de1(suuid))] == ""} {
 			::bt::msg -DEBUG "DE1 not connected, cannot send BLE command $command_name"
 			return

--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -1869,8 +1869,7 @@ proc de1_ble_handler { event data } {
 						} else {
 							if {$address == $::settings(bluetooth_address)} {
 								if {$cuuid eq $::de1(cuuid_02)} {
-									parse_state_change $value arr
-									::bt::msg -INFO "ACK state change written to DE1: '[array get arr]'"
+									::bt::msg -INFO "ACK state change written to DE1: $value_for_log"
 								} elseif {$cuuid eq $::de1(cuuid_06)} {
 									if {$::de1(currently_erasing_firmware) == 1 && $::de1(currently_updating_firmware) == 0} {
 										# erase ack received

--- a/de1plus/de1_comms.tcl
+++ b/de1plus/de1_comms.tcl
@@ -36,6 +36,12 @@ proc comms_msg {args} {
 }
 
 proc userdata_append {comment cmd {vital 0} } {
+
+	if { $::de1::_emergency_shutdown && [lindex $cmd 0] == "de1_comm" } {
+	    return
+	}
+
+
 	#set cmds [ble userdata $::de1(device_handle)]
 	#lappend cmds $cmd
 	#ble userdata $::de1(device_handle) $cmds
@@ -158,6 +164,9 @@ proc run_next_userdata_cmd {} {
 
 ### Generics
 proc de1_comm {action command_name {data 0}} {
+
+	if { $::de1::_emergency_shutdown } { return }
+
 	comms_msg -DEBUG "de1_comm sending action $action command $command_name data \"$data\""
 	if {$::de1(connectivity) == "ble"} {
 		return [de1_ble $action $command_name $data]

--- a/de1plus/de1_de1.tcl
+++ b/de1plus/de1_de1.tcl
@@ -411,7 +411,13 @@ namespace eval ::de1 {
 
 namespace eval ::de1::state {
 
+	variable _state_text "unknown"
+	variable _substate_text "unknown"
+
 	proc init {} {
+
+		set ::de1::state::_state_text "unknown"
+		set ::de1::state::_substate_text "unknown"
 
 		::de1::state::reset_framenumbers
 		unset -nocomplain ::de1::state::_previous_shotsample_update_time
@@ -421,12 +427,12 @@ namespace eval ::de1::state {
 
 	proc current_state {} {
 
-		expr { $::de1_num_state($::de1(state)) }
+		return $::de1::state::_state_text
 	}
 
 	proc current_substate {} {
 
-		expr { $::de1_substate_types($::de1(substate)) }
+		return $::de1::state::_substate_text
 	}
 
 	proc is_flow_state {{state_text "None"} {substate_text "None"}} {

--- a/de1plus/gui.tcl
+++ b/de1plus/gui.tcl
@@ -981,14 +981,14 @@ proc show_going_to_sleep_page  {} {
 		}
 	}
 
-	if {$::de1_num_state($::de1(state)) != "Idle"} {
+	if {[::de1::state::current_state] != "Idle"} {
 		# never go to sleep if the DE1 is not idle
-		msg -INFO "delaying screen saver because de1 is not idle: '$::de1_num_state($::de1(state))'"
+		msg -INFO "delaying screen saver because de1 is not idle: '[::de1::state::current_state]'"
 		delay_screen_saver
 		return
 	}
 
-    if {[ifexists ::app_updating] == 1} {
+	if {[ifexists ::app_updating] == 1} {
 		msg -INFO "delaying screen saver because tablet app is updating"
 		delay_screen_saver
 		return
@@ -998,7 +998,7 @@ proc show_going_to_sleep_page  {} {
 		msg -INFO "delaying screen saver because firmware is updating"
 		delay_screen_saver
 		return
-	}	
+	}
 
 
 
@@ -1082,7 +1082,7 @@ proc de1_connected_state { {hide_delay 0} } {
 	if {$::android == 0} {
 
 		if {$elapsed > $hide_delay && $hide_delay != 0} {
-			if {$::de1(substate) != 0} {
+		    if {[::de1::state::current_substate] != "ready"} {
 				return [translate Wait]
 			}
 			return ""
@@ -1094,8 +1094,9 @@ proc de1_connected_state { {hide_delay 0} } {
 	if {$since_last_ping < 5} {
 		#borg spinner off
 
-		if {$::de1(substate) != 0} {
-			if {$::de1(substate) == 4 || $::de1(substate) == 5} {
+		if {[::de1::state::current_substate] != "ready"} {
+		    if { [::de1::state::current_substate] \
+				 in {"preinfusion" "pouring"} } {
 				# currently making espresso.
 				return ""
 			}
@@ -1545,7 +1546,7 @@ proc page_display_change {page_to_hide page_to_show args} {
 #	}
 #
 #
-#	if {$::settings(stress_test) == 1 && $::de1_num_state($::de1(state)) == "Idle" && [info exists ::idle_next_step] == 1} {
+#	if {$::settings(stress_test) == 1 && [::de1::state::current_state] == "Idle" && [info exists ::idle_next_step] == 1} {
 #
 #		msg "Doing next stress test step: '$::idle_next_step '"
 #		set todo $::idle_next_step 

--- a/de1plus/gui.tcl
+++ b/de1plus/gui.tcl
@@ -3217,12 +3217,71 @@ namespace eval ::gui::notify {
 
 			sav_stop {
 
-				borg toast [translate {Stopping for volume}]
+			    borg toast [translate {Stopping for volume}]
+			}
+
+			fatal_error {
+
+			    # DE1 state was "FatalError"
+
+			    set _this_state [lindex $args 0]
+			    set _this_substate [lindex $args 1]
+
+			    set _message1 \
+				    [format "%s: %s,%s" \
+					     [translate {CRITICAL: DE1 Reported Error State}] \
+					     $_this_state $_this_substate]
+			    set _message2 \
+				    [translate {A common reason is that the water tray needs manual filling.}]
+			    set _message3 \
+				    [join [list \
+					[translate {Please send a photo or your log to support.}] \
+					[translate {If this is not the reason, please try rebooting your DE1.}] \
+					[translate {If the problem persists. Please contact support.}] \
+				    ]]
+
+			    if { [ catch {
+				info_page "$_message1\n\n$_message2\n\n$_message3" \
+					[translate "Ok"] } result opts_dict ] } {
+
+					    msg -ERROR "$result\n$opts_dict"
+					    borg toast $_message1
+			    }
+			}
+
+			state_decode_error {
+
+			    # DE1 state or substate not found in binary ==> word array
+
+			    set _this_state [lindex $args 0]
+			    set _this_substate [lindex $args 1]
+
+			    set _message1 \
+				    [format "%s: %s,%s" \
+					     [translate {CRITICAL: Unexpected DE1 State}] \
+					     $_this_state $_this_substate]
+			    set _message2 \
+				    [translate {A common reason is that the water tray needs manual filling.}]
+			    set _message3 \
+				    [join [list \
+					[translate {Please send a photo or your log to support.}]
+					[translate {If this is not the reason, please try rebooting your DE1.}]
+					[translate {If the problem persists. Please contact support.}] \
+				    ]]
+
+			    if { [ catch {
+				info_page "$_message1\n\n$_message2\n\n$_message3" \
+					[translate "Ok"] } result opts_dict ] } {
+
+					    msg -ERROR "$result\n$opts_dict"
+					    borg toast $_message1
+			    }
 			}
 
 			default {
 
-				msg -ERROR "::gui::notify::de1_event called without matching event_id: $event_id $args"
+			    msg -ERROR "::gui::notify::de1_event called" \
+				    "without matching event_id: $event_id $args"
 			}
 		}
 	}

--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -522,7 +522,7 @@ array set ::de1_num_state_reversed [reverse_array ::de1_num_state]
 
 
 array set ::de1_substate_types {
-	-   "starting"
+	-	"starting"
 	0	"ready"
 	1	"heating"
 	2	"final heating"
@@ -540,8 +540,26 @@ array set ::de1_substate_types {
 	14	"CleanFillGroup"
 	15	"CleanSoak"
 	16	"CleanGroup"
-	17  "refill"
+	17	"refill"
 	18	"PausedSteam"
+
+	200	"Error_NaN"
+	201	"Error_Inf"
+	202	"Error_Generic"
+	203	"Error_ACC"
+	204	"Error_TSensor"
+	205	"Error_PSensor"
+	206	"Error_WLevel"
+	207	"Error_DIP"
+	208	"Error_Assertion"
+	209	"Error_Unsafe"
+	210	"Error_InvalidParm"
+	211	"Error_Flash"
+	212	"Error_OOM"
+	213	"Error_Deadline"
+	214	"Error_HiCurrent"
+	215	"Error_LoCurrent"
+	216	"Error_BootFill"
 }
 array set ::de1_substate_types_reversed [reverse_array ::de1_substate_types]
 


### PR DESCRIPTION
Passes the one-espresso test. Needs more testing before merge.

See _unknown state when out of water_ on Basecamp for more information

_Definitely time to sleep, missed too many misspellings, including misspelling misspelling._

Will also need version bumps prior to merge.

My daily-driver branch has been rebased on this for testing.