### PR TITLE
de1: Add volume_dispensed to on_shotvalue_available

### DIFF
--- a/de1plus/de1_de1.tcl
+++ b/de1plus/de1_de1.tcl
@@ -6,7 +6,7 @@
 # These are not in machine.tcl due to apparent assumptions on inclusion order
 #
 
-package provide de1_de1 1.3
+package provide de1_de1 1.4
 
 package require lambda
 
@@ -627,6 +627,9 @@ namespace eval ::de1::state::update {
 					event_time [expr {[clock milliseconds] / 1000.0}] \
 					update_received $update_received \
 					{*}[array get ShotSample] \
+					volume_dispensed \
+					    [expr { $::de1(preinfusion_volume) \
+							+ $::de1(pour_volume) }] \
 					this_state $this_state \
 					this_substate $this_substate \
 				       ]

--- a/de1plus/pkgIndex.tcl
+++ b/de1plus/pkgIndex.tcl
@@ -14,7 +14,7 @@ package ifneeded de1_event 1.0 [list source [file join "./" event.tcl]]
 package ifneeded de1_logging 1.2 [list source [file join "./" logging.tcl]]
 package ifneeded de1_profile 2.0 [list source [file join "./" profile.tcl]]
 package ifneeded de1_shot 2.0 [list source [file join "./" shot.tcl]]
-package ifneeded de1_de1 1.3 [list source [file join "./" de1_de1.tcl]]
+package ifneeded de1_de1 1.4 [list source [file join "./" de1_de1.tcl]]
 package ifneeded de1_device_scale 1.5 [list source [file join "./" device_scale.tcl]]
 
 package ifneeded de1_history_viewer 1.1 [list source [file join "./" history_viewer.tcl]]


### PR DESCRIPTION
Although the flow rate and timing is already available in the
event_dict for on_shotvalue_available, this is a common-enough
value needed by the GUI and shot-control extensions to have it
available in the event_dict directly.

Added "volume_dispensed" to the event_dict as the total of

  $::de1(preinfusion_volume)
  $::de1(pour_volume)

Frame information is available to consumers in the same event_dict
so that division by flow-phase, frame, or time, is possible.

Package version bump due to additive API change.

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>