### PR TITLE
Add DUI support for tk text widget

### DIFF
--- a/de1plus/app_metadata.tcl
+++ b/de1plus/app_metadata.tcl
@@ -266,7 +266,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget drater
 	}
-	metadata add espresso_note {
+	metadata add espresso_notes {
 		domain shot
 		category description
 		section extraction

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -299,9 +299,9 @@ namespace eval ::dui {
 		set fontawesome_pro [dui::font::add_or_get_familyname "Font Awesome 5 Pro-Regular-400.otf"]
 
 		msg -DEBUG [namespace current] "Font multiplier: $fontm"
-		dui aspect set -theme default -type text font_family $helvetica_font 
-		dui aspect set -theme default -type text -style bold font_family $helvetica_bold_font
-		dui aspect set -theme default -type text -style global font_family $global_font_name font_size $global_font_size
+		dui aspect set -theme default -type dtext font_family $helvetica_font 
+		dui aspect set -theme default -type dtext -style bold font_family $helvetica_bold_font
+		dui aspect set -theme default -type dtext -style global font_family $global_font_name font_size $global_font_size
 		#msg -DEBUG [namespace current] "Adding global font with family=$global_font_name and size=$global_font_size"		
 		dui aspect set -theme default -type symbol font_family $fontawesome_pro
 		dui aspect set -theme default -type symbol -style brands font_family $fontawesome_brands
@@ -688,22 +688,22 @@ namespace eval ::dui {
 			default.font.font_family notosansuiregular
 			default.font.font_size 16
 			
-			default.text.font_family notosansuiregular
-			default.text.font_size 16
-			default.text.fill "#7f879a"
-			default.text.disabledfill "#ddd"
-			default.text.anchor nw
-			default.text.justify left
+			default.dtext.font_family notosansuiregular
+			default.dtext.font_size 16
+			default.dtext.fill "#7f879a"
+			default.dtext.disabledfill "#ddd"
+			default.dtext.anchor nw
+			default.dtext.justify left
 			
-			default.text.fill.remark "#4e85f4"
-			default.text.fill.error red
-			default.text.font_family.section_title notosansuibold
+			default.dtext.fill.remark "#4e85f4"
+			default.dtext.fill.error red
+			default.dtext.font_family.section_title notosansuibold
 			
-			default.text.font_family.page_title notosansuibold
-			default.text.font_size.page_title 26
-			default.text.fill.page_title "#35363d"
-			default.text.anchor.page_title center
-			default.text.justify.page_title center
+			default.dtext.font_family.page_title notosansuibold
+			default.dtext.font_size.page_title 26
+			default.dtext.fill.page_title "#35363d"
+			default.dtext.anchor.page_title center
+			default.dtext.justify.page_title center
 						
 			default.symbol.font_family "Font Awesome 5 Pro-Regular-400"
 			default.symbol.font_size 55
@@ -868,6 +868,11 @@ namespace eval ::dui {
 			default.graph_line.linewidth 6
 			default.graph_line.pixels 0 
 			default.graph_line.smooth linear
+			
+			default.text.bg white
+			default.text.font_size 16
+			default.text.relief flat
+			default.text.highlightthickness 1
 		}
 		
 		# Named options:
@@ -3630,11 +3635,11 @@ namespace eval ::dui {
 					remove_options -font_$f largs
 				}
 			} elseif { $type ni {ProgressBar} } {
-				set font_family [get_option -font_family [dui aspect get [list $type text font] font_family -style $style] 1 largs]
+				set font_family [get_option -font_family [dui aspect get [list $type dtext font] font_family -style $style] 1 largs]
 				
-				set default_size [dui aspect get [list $type text font] font_size]
+				set default_size [dui aspect get [list $type dtext font] font_size]
 				if { $default_size eq "" || [string range $default_size 0 0] in "- +" } {
-					set default_size [dui aspect get [list text font] font_size]
+					set default_size [dui aspect get [list dtext font] font_size]
 					if { $default_size eq "" || [string range $default_size 0 0] in "- +" } {
 						set default_size [dui aspect get font font_size]
 						if { $default_size eq "" || [string range $default_size 0 0] in "- +" } {
@@ -3687,9 +3692,9 @@ namespace eval ::dui {
 			
 			set label_tags [list ${main_tag}-lbl {*}[lrange $tags 1 end]]
 			set label_args [extract_prefixed -label_ largs]
-			foreach aspect [dui aspect list -type [list ${type}_label text] -style $style] {
+			foreach aspect [dui aspect list -type [list ${type}_label dtext] -style $style] {
 				add_option_if_not_exists -$aspect [dui aspect get ${type}_label $aspect -style $style \
-					-default {} -default_type text] label_args
+					-default {} -default_type dtext] label_args
 			}
 						
 			set label_pos [get_option -pos "w -20 0" 1 label_args]
@@ -5697,15 +5702,15 @@ namespace eval ::dui {
 			set x [dui platform rescale_x $x]
 			set y [dui platform rescale_y $y]
 			
-			set tags [dui::args::process_tags_and_var $pages text ""]
+			set tags [dui::args::process_tags_and_var $pages dtext ""]
 			set main_tag [lindex $tags 0]
 			set cmd [dui::args::get_option -command {} 1]
 			
 			set compatibility_mode [string is true [dui::args::get_option -compatibility_mode 0 1]]
 			if { ! $compatibility_mode } {				
 				set style [dui::args::get_option -style "" 1]
-				dui::args::process_aspects text $style "" "pos"
-				dui::args::process_font text $style
+				dui::args::process_aspects dtext $style "" "pos"
+				dui::args::process_font dtext $style
 				set width [dui::args::get_option -width {} 1]
 				if { $width ne "" } {
 					set width [dui platform rescale_x $width]
@@ -5716,7 +5721,7 @@ namespace eval ::dui {
 			try {
 				set id [$can create text $x $y -state hidden {*}$args]
 			} on error err {
-				set msg "can't add text '$main_tag' in page(s) '$pages' to canvas: $err"
+				set msg "can't add dtext '$main_tag' in page(s) '$pages' to canvas: $err"
 				msg -ERROR [namespace current] $msg
 				error $msg
 				return
@@ -5738,7 +5743,7 @@ namespace eval ::dui {
 				$can bind $id [dui platform button_press] $cmd
 			}
 			
-			#msg -INFO [namespace current] text "'$main_tag' to page(s) '$pages' with args '$args'"
+			#msg -INFO [namespace current] dtext "'$main_tag' to page(s) '$pages' with args '$args'"
 			return $id
 		}
 		
@@ -5877,9 +5882,9 @@ namespace eval ::dui {
 				set "label${suffix}_tags" [list "${main_tag}-lbl$suffix" {*}[lrange $tags 1 end]]	
 				set "label${suffix}_args" [dui::args::extract_prefixed "-label${suffix}_"]
 				
-				foreach aspect [dui aspect list -type [list "${aspect_type}_label$suffix" text] -style $style] {
+				foreach aspect [dui aspect list -type [list "${aspect_type}_label$suffix" dtext] -style $style] {
 					dui::args::add_option_if_not_exists -$aspect [dui aspect get "${aspect_type}_label$suffix" $aspect \
-						-style $style -default {} -default_type text] "label${suffix}_args"
+						-style $style -default {} -default_type dtext] "label${suffix}_args"
 				}
 				
 				set "label${suffix}_pos" [dui::args::get_option -pos {0.5 0.5} 1 "label${suffix}_args"]
@@ -6167,7 +6172,7 @@ if { $main_tag eq "match_current_btn" } { msg "BUTTON ARGS: $args "}
 		#		negative x and y offsets. The marker and offsets are used in a relocate_text_wrt call on the page show 
 		#		event, so that it is repositioned dynamically for widgets whose size is defined in characters instead
 		#		of pixels.
-		#	-label_* passed through to 'add text'
+		#	-label_* passed through to 'add dtext'
 		#	-tclcode code to be evaluated after the widget is created, to allow configuring the widget. It is evaluated
 		#		in a global context, and performs the following substitutions:
 		#			%W the widget pathname
@@ -7083,7 +7088,7 @@ if { $main_tag eq "match_current_btn" } { msg "BUTTON ARGS: $args "}
 			set main_tag [lindex $tags 0]
 			
 			#set style [dui::args::get_option -style "" 0]
-			dui::args::process_aspects tk_text
+			dui::args::process_aspects text
 			
 			set width [dui::args::get_option -width "" 1]
 			if { $width ne "" } {
@@ -7441,11 +7446,11 @@ namespace eval ::dui::pages::dui_number_editor {
 		
 		if { $data(value) ne "" } {
 			if { $data(min) ne "" && $data(value) < $data(min) } {
-				$widget configure -foreground [dui aspect get text fill -style error]
+				$widget configure -foreground [dui aspect get dtext fill -style error]
 			} elseif { $data(max) ne "" && $data(value) > $data(max) } {
-				$widget configure -foreground [dui aspect get text fill -style error]
+				$widget configure -foreground [dui aspect get dtext fill -style error]
 			} else {
-				$widget configure -foreground [dui aspect get text fill]
+				$widget configure -foreground [dui aspect get dtext fill]
 			}
 		}
 	}

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -3725,7 +3725,7 @@ namespace eval ::dui {
 			}
 
 			if { $label ne "" } {
-				set id [dui add text $pages $xlabel $ylabel -text $label -tags $label_tags -aspect_type ${type}_label \
+				set id [dui add dtext $pages $xlabel $ylabel -text $label -tags $label_tags -aspect_type ${type}_label \
 					{*}$label_args]
 			} elseif { $labelvar ne "" } {
 				set id [dui add variable $pages $xlabel $ylabel -textvariable $labelvar -tags $label_tags \
@@ -5691,7 +5691,7 @@ namespace eval ::dui {
 		#	-compatibility_mode: set to 0 to be backwards-compatible with add_de1_text calls (don't apply aspects,
 		#		font suboptions and don't rescale width)
 		#	All others passed through to the 'canvas create text' command
-		proc text { pages x y args } {
+		proc dtext { pages x y args } {
 			global text_cnt
 			set can [dui canvas]
 			set x [dui platform rescale_x $x]
@@ -5750,7 +5750,7 @@ namespace eval ::dui {
 		# 		If -textvariable gives a plain name instead of code to be evaluted (no brackets, parenthesis, ::, etc.) 
 		#		and the first page in 'pages' is a namespace, uses {$::dui::pages::<page>::data(<textvariable>)}. 
 		#		Also in this case, if -tags is not specified, uses the textvariable name as tag.
-		# All others passed through to the 'dui add text' command
+		# All others passed through to the 'dui add dtext' command
 		proc variable { pages x y args } {
 			global variable_labels
 			
@@ -5758,7 +5758,7 @@ namespace eval ::dui {
 			set main_tag [lindex $tags 0]
 			set varcode [dui::args::get_option -textvariable "" 1]
 	
-			set id [dui add text $pages $x $y {*}$args]
+			set id [dui add dtext $pages $x $y {*}$args]
 			dui page add_variable $pages $id $varcode
 			return $id
 		}
@@ -5778,7 +5778,7 @@ namespace eval ::dui {
 			
 			dui::args::add_option_if_not_exists -aspect_type symbol
 			
-			return [dui add text $pages $x $y -text $symbol {*}$args]
+			return [dui add dtext $pages $x $y -text $symbol {*}$args]
 		}
 		
 		# Add dbutton items to the canvas. Returns the list of all added tags (one per page).
@@ -5806,7 +5806,7 @@ namespace eval ::dui {
 		#	-labelvariable, -label1variable... to use a variable as label text
 		#	-label_pos, -label1_pos... a list with 2 elements between 0 and 1 that specify the x and y percentages where to position
 		#		the label inside the button
-		#	-label_* (-label_fill -label_outline etc.) are passed through to 'dui add text' or 'dui add variable'
+		#	-label_* (-label_fill -label_outline etc.) are passed through to 'dui add dtext' or 'dui add variable'
 		#	-symbol to add a Fontawesome symbol/icon to the button, on position -symbol_pos, and using option values
 		#		given in -symbol_* that are passed through to 'dui add symbol'
 		#	-radius for rounded rectangles, and -arc_offset for rounded outline rectangles
@@ -6003,7 +6003,7 @@ if { $main_tag eq "match_current_btn" } { msg "BUTTON ARGS: $args "}
 			while { ([info exists label$suffix] && [subst \$label$suffix] ne "") || 
 					([info exists labelvar$suffix] && [subst \$labelvar$suffix] ne "") } {
 				if { [info exists label$suffix] && [subst \$label$suffix] ne "" } {
-					dui add text $pages [subst \$xlabel$suffix] [subst \$ylabel$suffix] -text [subst \$label$suffix] \
+					dui add dtext $pages [subst \$xlabel$suffix] [subst \$ylabel$suffix] -text [subst \$label$suffix] \
 						-tags [subst \$label${suffix}_tags] -aspect_type "dbutton_label$suffix" \
 						-style $style {*}[subst \$label${suffix}_args]
 				} elseif { [info exists labelvar$suffix] && [subst \$labelvar$suffix] ne "" } {
@@ -7078,7 +7078,7 @@ if { $main_tag eq "match_current_btn" } { msg "BUTTON ARGS: $args "}
 			
 		}
 		
-		proc tk_text { pages x y args } {
+		proc text { pages x y args } {
 			set tags [dui::args::process_tags_and_var $pages tk_text {} 1]
 			set main_tag [lindex $tags 0]
 			

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -729,7 +729,7 @@ namespace eval ::dui {
 			default.dbutton_label.anchor center	
 			default.dbutton_label.justify center
 			default.dbutton_label.fill white
-			default.dbutton_label.disabledfill "#ddd"
+			default.dbutton_label.disabledfill "#ccc"
 
 			default.dbutton_label1.pos {0.5 0.8}
 			default.dbutton_label1.font_size 16
@@ -5866,7 +5866,7 @@ namespace eval ::dui {
 			set ry [dui platform rescale_y $y]
 			set ry1 [dui platform rescale_y $y1]
 					
-			set tags [dui::args::process_tags_and_var $pages dbutton {} 1]
+			set tags [dui::args::process_tags_and_var $pages dbutton {} 1 args 1]
 			set main_tag [lindex $tags 0]
 			set button_tags [list ${main_tag}-btn {*}[lrange $tags 1 end]]
 			

--- a/de1plus/gui.tcl
+++ b/de1plus/gui.tcl
@@ -311,36 +311,37 @@ proc vertical_slider {varname minval maxval x y x0 y0 x1 y1} {
 # on android we track finger-down, instead of button-press, as it gives us lower latency by avoding having to distinguish a potential gesture from a tap
 # finger down gives a http://blog.tcl.tk/39474
 proc translate_coordinates_finger_down_x { x } {
-
-	if {$::android == 1 && $::settings(use_finger_down_for_tap) == 1} {
-	 	return [expr {$x * [winfo screenwidth .] / 10000}]
-	 }
-	 return $x
+	return [dui::platform::translate_coordinates_finger_down_x $x]
+#	if {$::android == 1 && $::settings(use_finger_down_for_tap) == 1} {
+#	 	return [expr {$x * [winfo screenwidth .] / 10000}]
+#	 }
+#	 return $x
 }
 proc translate_coordinates_finger_down_y { y } {
-
-	if {$::android == 1 && $::settings(use_finger_down_for_tap) == 1} {
-	 	return [expr {$y * [winfo screenheight .] / 10000}]
-	 }
-	 return $y
+	return [dui platform translate_coordinates_finger_down_y $y ]	
+#	if {$::android == 1 && $::settings(use_finger_down_for_tap) == 1} {
+#	 	return [expr {$y * [winfo screenheight .] / 10000}]
+#	 }
+#	 return $y
 }
 
 proc is_fast_double_tap { key } {
-	# if this is a fast double-tap, then treat it like a long tap (button-3) 
-
-	set b 0
-	set millinow [clock milliseconds]
-	set prevtime [ifexists ::last_click_time($key)]
-	if {$prevtime != ""} {
-		# check for a fast double-varName
-		if {[expr {$millinow - $prevtime}] < 150} {
-			msg -INFO "Fast button double-tap on $key"
-			set b 1
-		}
-	}
-	set ::last_click_time($key) $millinow
-
-	return $b
+	return [dui platform is_fast_double_tap $key]
+#	# if this is a fast double-tap, then treat it like a long tap (button-3) 
+#
+#	set b 0
+#	set millinow [clock milliseconds]
+#	set prevtime [ifexists ::last_click_time($key)]
+#	if {$prevtime != ""} {
+#		# check for a fast double-varName
+#		if {[expr {$millinow - $prevtime}] < 150} {
+#			msg -INFO "Fast button double-tap on $key"
+#			set b 1
+#		}
+#	}
+#	set ::last_click_time($key) $millinow
+#
+#	return $b
 }
 
 proc vertical_clicker {bigincrement smallincrement varname minval maxval x y x0 y0 x1 y1 {b 0} } {

--- a/de1plus/gui.tcl
+++ b/de1plus/gui.tcl
@@ -802,7 +802,7 @@ proc maxstring {in maxlength {optmsg {}} } {
 
 #set text_cnt 0
 proc add_de1_text {args} {
-	return [dui add text [lindex $args 0] [lindex $args 1] [lindex $args 2] -compatibility_mode 1 {*}[lrange $args 3 end]]
+	return [dui add dtext [lindex $args 0] [lindex $args 1] [lindex $args 2] -compatibility_mode 1 {*}[lrange $args 3 end]]
 	
 #	global text_cnt
 #	incr text_cnt

--- a/de1plus/history_viewer.tcl
+++ b/de1plus/history_viewer.tcl
@@ -341,10 +341,10 @@ namespace eval ::history_viewer {
 				dbutton_label.pos.hv_done_button {0.6 0.5} 
 				dbutton_label.width.hv_done_button 360
 				
-				text.font_size.hv_shot_params -1
+				dtext.font_size.hv_shot_params -1
 				
-				text.anchor.hv_graph_title center 
-				text.justify.hv_graph_title center 
+				dtext.anchor.hv_graph_title center 
+				dtext.justify.hv_graph_title center 
 				
 				graph.background.hv_graph $bg_color 
 				graph.plotbackground.hv_graph $bg_color 

--- a/de1plus/utils.tcl
+++ b/de1plus/utils.tcl
@@ -56,10 +56,10 @@ proc setup_environment {} {
 	
 	# Create hardcoded fonts used in default and Insight skins. These should be replaced by DUI aspects in the future,
 	# but are left at the moment to guarantee backwards-compatibility.
-	set helvetica_font [dui aspect get text font_family -theme default]
-	set helvetica_bold_font [dui aspect get text font_family -theme default -style bold]
-	set global_font_name [dui aspect get text font_family -theme default -style global]
-	set global_font_size [dui aspect get text font_size -theme default -style global]
+	set helvetica_font [dui aspect get dtext font_family -theme default]
+	set helvetica_bold_font [dui aspect get dtext font_family -theme default -style bold]
+	set global_font_name [dui aspect get dtext font_family -theme default -style global]
+	set global_font_size [dui aspect get dtext font_size -theme default -style global]
 	set fontawesome_brands [dui aspect get symbol font_family -theme default -style brands]
 		
 	if {$android == 1 || $undroid == 1} {

--- a/documentation/decent_user_interface.md
+++ b/documentation/decent_user_interface.md
@@ -44,6 +44,7 @@ toolkit basics), and the [TkDocs online tutorial](https://tkdocs.com/).
 ## Revision History
 
 * 2021-04-10 – Initial writing by [Enrique Bengoechea](https://github.com/ebengoechea)
+* 2021-04-10 - 2021-05-14 - Rewrite while the API evolves through nightly & beta, by [Enrique Bengoechea](https://github.com/ebengoechea)
 
 <a name="history"></a>
 
@@ -253,10 +254,10 @@ dui theme current dark
 dui page add test_page
 
 # Will use a bigger font, otherwise will use the theme text.* aspects
-dui add text test_page 1280 100 -text [translate "Tab title"] -style tab_header
+dui add dtext test_page 1280 100 -text [translate "Tab title"] -style tab_header
 
 # Will use all text.* aspects from the dark theme, except -fill
-dui add text test_page 200 200 -text [translate "Some text"] -fill black
+dui add dtext test_page 200 200 -text [translate "Some text"] -fill black
 ```
 
 <a name="aspects_api"></a>
@@ -1069,9 +1070,9 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 >Generic command to create Tk widgets of type  _type_  and add them to DUI pages. Many widgets like **entry** or **listbox** have their own **dui add** command with extra features, but this is offered for extensions and other non directly supported widgets.
 
 
-<a name="dui_add_text"></a>
+<a name="dui_add_dtext"></a>
 
-**dui add text**  _pages x y ?-option value ...?_
+**dui add dtext**  _pages x y ?-option value ...?_
 
 >Create a text label and add it to the requested  _pages_  at coordinates  _{x, y}_ . 
 
@@ -1185,7 +1186,7 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 
 >**-label&lt;i&gt;_***option*** **  _value_
 
-> >Use this syntax to pass additional options to the label creation command. They will be passed through to either **dui add text** if **-label** was used, or to **dui add variable** if **-labelvariable** was used.
+> >Use this syntax to pass additional options to the label creation command. They will be passed through to either **dui add dtext** if **-label** was used, or to **dui add variable** if **-labelvariable** was used.
 
 >**-symbol**  _symbol_name_
 
@@ -1347,7 +1348,7 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 
 >**-label_***option*** **  _value_
 
-> >Use this syntax to pass additional options to the label creation command. They will be passed through to either **dui add text** if **-label** was used, or to **dui add variable** if **-labelvariable** was used.
+> >Use this syntax to pass additional options to the label creation command. They will be passed through to either **dui add dtext** if **-label** was used, or to **dui add variable** if **-labelvariable** was used.
 
 
 <a name="dui_add_multiline_entry"></a>
@@ -1390,7 +1391,7 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 
 >**-label_***option*** **  _value_
 
-> >Use this syntax to pass additional options to the label creation command. They will be passed through to either **dui add text** if **-label** was used, or to **dui add variable** if **-labelvariable** was used.
+> >Use this syntax to pass additional options to the label creation command. They will be passed through to either **dui add dtext** if **-label** was used, or to **dui add variable** if **-labelvariable** was used.
 
 >**-yscrollbar**  _true_or_false_
 
@@ -1435,7 +1436,7 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 
 >**-label_***option*** **  _value_
 
-> >Use this syntax to pass additional options to the label creation command. They will be passed through to either **dui add text** if **-label** was used, or to **dui add variable** if **-labelvariable** was used.
+> >Use this syntax to pass additional options to the label creation command. They will be passed through to either **dui add dtext** if **-label** was used, or to **dui add variable** if **-labelvariable** was used.
 
 >**-yscrollbar**  _true_or_false_
 
@@ -1663,3 +1664,48 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 **dui add graph**  _pages x y ?-option value ...?_
 
 >Create a BLT graph widget and add it to the requested  _pages_  at coordinates  _{x, y}_ . 
+
+
+<a name="dui_add_text"></a>
+
+**dui add text**  _pages x y ?-option value ...?_
+
+>Create a Tk text widget and add it to the requested  _pages_  at coordinates  _{x, y}_ . 
+
+>Return the pathname of the Text widget. The command also adds (if applicable) the following named tags to the canvas, and the same keys in the widgets page namespace array: 
+
+> >&lt;main_tag&gt;: the Text widget.
+
+> >&lt;main_tag&gt;-lbl: (optional) the canvas ID of the label text.
+
+> >&lt;main_tag&gt;-ysb: (optional) the Tk scale widget used as vertical scrollbar.
+
+>Non-DUI options are passed-through to the Tk [text](https://www.tcl.tk/man/tcl8.6/TkCmd/text.htm) command.
+
+>**-label**  _text_
+
+>**-labelvariable**  _tcl_code_
+
+> >If **-label** or **-labelvariable** are used, adds a fixed or dynamic text label, respectively, associated to the text widget.
+
+>**-label_pos**  _{x y}_
+
+>**-label_pos**  _{anchor ?x_offset? ?y_offset?}_
+
+> >A list that determines the location of the label. If a pair of numeric coordinates are provided, they are interpreted as direct coordinates in the screen. If the first list item is not a number, it is interpreted as an anchor point relative to the edges of the listbox widget, and the label will be moved to the target position when the page is shown. 
+
+> >Valid anchor values are "n", "nw", "ne", "s", "sw", "se", "w", "wn", "ws", "e", "en", "es". To get the label placed exactly as you want you normally also have to play with **-label_anchor** and **-label_justify**.
+
+> >The anchor value can optionally be followed by an  _x_offset_  and a  _y_offset_ , which will move the position by those fixed offsets after the anchor point is determined.
+
+>**-label_***option*** **  _value_
+
+> >Use this syntax to pass additional options to the label creation command. They will be passed through to either **dui add dtext** if **-label** was used, or to **dui add variable** if **-labelvariable** was used.
+
+>**-yscrollbar**  _true_or_false_
+
+> >If  _true_ , a vertical scrollbar is added to the right side of the text widget. The scrollbar is actually a Tk scale widget, not a Tk scrollbar widget. 
+
+>**-yscrollbar_***option*** **  _value_
+
+> >Use this syntax to pass additional options to the yscrollbar scale creation command.


### PR DESCRIPTION
- Adds new command 'add dui text' for adding Tk text widgets.
- Renames 'add dui text' to 'add dui dtext'. This is done for consistency of the API, as whenever a Tk widget exists 'dui add <widget_type>' is the command to add it, and 'dui add d<widget_type>' is the canvas-based DUI version. 
- Fixes an error in the vertical scrolling of Tk text and multineline_entries
- Commands translate_coordinate_finger_down_x, translate_coordinate_finger_down_x and is_fast_double_tap moved to DUI.
