### PR TITLE
Metadata package 

### DIFF
--- a/de1plus/app_metadata.tcl
+++ b/de1plus/app_metadata.tcl
@@ -1,0 +1,318 @@
+
+proc init_app_metadata {} {
+	# Define the properties to be used in the app data dictionary
+	metadata dictionary add domain [list validate_category {shot profile}]
+	metadata dictionary add category validate_nonempty_string
+	metadata dictionary add section validate_nonempty_string
+	metadata dictionary add subsection validate_nonempty_string
+	metadata dictionary add owner_type [list validate_category {base skin plugin}]
+	metadata dictionary add owner
+	metadata dictionary add name validate_nonempty_string
+	metadata dictionary add name_plural validate_nonempty_string
+	metadata dictionary add short_name validate_nonempty_string
+	metadata dictionary add short_name_plural validate_nonempty_string
+	metadata dictionary add description
+	metadata dictionary add propagate validate_boolean
+	metadata dictionary add data_type [list validate_category {text long_text category number boolean date}]
+	metadata dictionary add required boolean
+	metadata dictionary add length validate_length
+	metadata dictionary add valid_values
+	metadata dictionary add min [list string is double]
+	metadata dictionary add max [list string is double]
+	metadata dictionary add default
+	metadata dictionary add smallincrement [list string is double]
+	metadata dictionary add bigincrement [list string is double]
+	metadata dictionary add n_decimals [list string is integer]
+	metadata dictionary add measure_unit
+	metadata dictionary add default_dui_widget [list validate_category {entry text listbox dcombobox dcheckbox drater dclicker}]	
+	
+	# Define the actual fields
+	metadata add profile_title {
+		domain {profile shot}
+		owner_type base
+		name "Profile title"
+		name_plural "Profile titles"
+		short_name "Profile" 
+		short_name_plural "Profiles"
+		propagate 0
+		data_type category
+		required 1
+		length 1
+		default_dui_widget dcombobox
+	}
+	metadata add bean_brand {
+		domain shot
+		category description
+		section beans
+		subsection beans_desc
+		owner_type base
+		name "Beans roaster"
+		name_plural "Beans roaster"
+		short_name "Roaster" 
+		short_name_plural "Roasters"
+		propagate 1
+		data_type category
+		required 0
+		length list
+		default_dui_widget dcombobox
+	}
+	metadata add bean_type {
+		domain shot
+		category description
+		section beans
+		subsection beans_desc
+		owner_type base
+		name "Beans type"
+		name_plural "Beans type"
+		short_name "Beans" 
+		short_name_plural "Beans"
+		propagate 1
+		data_type category
+		required 0
+		length list
+		default_dui_widget dcombobox
+	}
+	metadata add roast_date {
+		domain shot
+		category description
+		section beans
+		subsection beans_batch
+		owner_type base
+		name "Roast date"
+		name_plural "Roast dates"
+		short_name "Roasted" 
+		short_name_plural "Roasted"
+		propagate 1
+		data_type text
+		required 0
+		length 1
+		default_dui_widget entry
+	}
+	metadata add roast_level {
+		domain shot
+		category description
+		section beans
+		subsection beans_batch
+		owner_type base
+		name "Roast level"
+		name_plural "Roast levels"
+		short_name "Roast lvl" 
+		short_name_plural "Roast lvls"
+		propagate 1
+		data_type category
+		required 0
+		length 1
+		default_dui_widget dcombobox
+	}
+	metadata add bean_notes {
+		domain shot
+		category description
+		section beans
+		subsection beans_batch
+		owner_type base
+		name "Beans notes"
+		name_plural "Beans notes"
+		short_name "Notes" 
+		short_name_plural "Notes"
+		propagate 1
+		data_type long_text
+		required 0
+		length 1
+		default_dui_widget text
+	}		
+	metadata add grinder_model {
+		domain shot
+		category description
+		section equipment
+		subsection grinder
+		owner_type base
+		name "Grinder model"
+		name_plural "Grinder models"
+		short_name "Grinder" 
+		short_name_plural "Grinders"
+		propagate 1
+		data_type category
+		required 0
+		length 1
+		default_dui_widget dcombobox
+	}
+	metadata add grinder_setting {
+		domain shot
+		category description
+		section equipment
+		subsection grinder
+		owner_type base
+		name "Grinder setting"
+		name_plural "Grinder settings"
+		short_name "Grinder set" 
+		short_name_plural "Grinder sets"
+		propagate 1
+		data_type category
+		required 0
+		length 1
+		default_dui_widget dcombobox
+	}
+	metadata add grinder_dose_weight {
+		domain shot
+		category description
+		section extraction
+		subsection ""
+		owner_type base
+		name "Dose weight"
+		name_plural "Dose weights"
+		short_name "Dose" 
+		short_name_plural "Doses"
+		propagate 1
+		data_type number
+		min 0.0
+		max 30.0
+		default 18.0
+		smallincrement 0.1
+		bigincrement 1.0
+		n_decimals 1
+		measure_unit g
+		required 0
+		length 1
+		default_dui_widget dclicker
+	}
+	metadata add drink_weight {
+		domain shot
+		category description
+		section extraction
+		subsection drink
+		owner_type base
+		name "Drink weight"
+		name_plural "Drink weights"
+		short_name "Yield" 
+		short_name_plural "Yields"
+		propagate 1
+		data_type number
+		min 0.0
+		max 500.0
+		default 36.0
+		smallincrement 1.0
+		bigincrement 10.0
+		n_decimals 1
+		measure_unit g
+		required 0
+		length 1
+		default_dui_widget dclicker
+	}
+	metadata add drink_tds {
+		domain shot
+		category description
+		section extraction
+		subsection drink
+		owner_type base
+		name "Total Dissolved Solids"
+		name_plural "Total Dissolved Solids"
+		short_name "TDS" 
+		short_name_plural "TDS"
+		propagate 0
+		data_type number
+		min 0.0
+		max 15.0
+		default 8.0
+		smallincrement 0.01
+		bigincrement 0.1
+		n_decimals 2
+		measure_unit %
+		required 0
+		length 1
+		default_dui_widget dclicker
+	}
+	metadata add drink_ey {
+		domain shot
+		category description
+		section extraction
+		subsection drink
+		owner_type base
+		name "Extraction Yield"
+		name_plural "Extraction Yields"
+		short_name "EY" 
+		short_name_plural "EY"
+		propagate 0
+		data_type number
+		min 0.0
+		max 15.0
+		default 8.0
+		smallincrement 0.01
+		bigincrement 0.1
+		n_decimals 2
+		measure_unit %
+		required 0
+		length 1
+		default_dui_widget dclicker
+	}
+	metadata add espresso_enjoyment {
+		domain shot
+		category description
+		section extraction
+		subsection tasting
+		owner_type base
+		name "Enjoyment (0-100)"
+		name_plural "Enjoyment"
+		short_name "Enjoyment" 
+		short_name_plural "Enjoyment"
+		propagate 0
+		data_type number
+		min 0
+		max 100
+		default 50
+		smallincrement 1
+		bigincrement 10
+		n_decimals 0
+		required 0
+		length 1
+		default_dui_widget drater
+	}
+	metadata add espresso_note {
+		domain shot
+		category description
+		section extraction
+		subsection tasting
+		owner_type base
+		name "Espresso note"
+		name_plural "Espresso notes"
+		short_name "Note" 
+		short_name_plural "Notes"
+		propagate 0
+		data_type long_text
+		required 0
+		length 1
+		default_dui_widget text
+	}
+	metadata add my_name {
+		domain shot
+		category description
+		section people
+		subsection ""
+		owner_type base
+		name "Barista"
+		name_plural "Baristas"
+		short_name "Barista" 
+		short_name_plural "Baristas"
+		propagate 1
+		data_type category
+		required 0
+		length 1
+		default_dui_widget dcombobox
+	}
+	metadata add beverage_type {
+		domain profile
+		category machine?
+		section drink
+		subsection ""
+		owner_type base
+		name "Beverage type"
+		name_plural "Beverage types"
+		short_name "Bev. type" 
+		short_name_plural "Bev. types"
+		propagate 0
+		data_type category
+		values {espresso tea_portafilter cleaning calibrate}
+		required 1
+		length 1
+		default_dui_widget dcombobox
+	}	
+}

--- a/de1plus/metadata.tcl
+++ b/de1plus/metadata.tcl
@@ -1,0 +1,167 @@
+package provide de1_metadata 1.0
+
+package require de1_logging 1.0
+package require de1_updater 1.1
+package require de1_utils 1.1
+
+namespace eval ::metadata {
+	namespace export *
+	namespace ensemble create
+
+	# Data Dictionary
+	variable dd
+	set dd [dict create]
+	
+	# Invoking 'init' resets all existing metadata
+	proc init { } {
+		variable dd		
+		metadata dictionary init
+		set dd [dict create]
+	}
+
+	namespace eval dictionary  {
+		namespace export *
+		namespace ensemble create
+		
+		variable properties
+		set properties [dict create]
+		
+		proc init {} {
+			variable properties
+			set properties [dict create]
+		}
+		
+		proc add { prop {vcmd {}} } {
+			variable properties
+			if { [dict exists $properties $prop] } {
+				msg -WARNING [namespace current] "add: property name '$prop' already exists in the metadata data dictionary, duplicates not allowed"
+				return
+			}
+			set first_cmd [lindex $$vcmd 0]
+			if { [string is wordchar -strict $first_cmd] && [namespace which -command [namespace current]::$first_cmd] ne "" } {
+				lset vcmd 0 0 [namespace current]::$first_cmd
+			}
+			dict set properties $prop $vcmd
+		}
+
+		proc properties { args } {
+			variable properties
+			return [dict keys $properties {*}$args]
+		}
+
+		proc exists { prop } {
+			variable properties
+			return [dict exists $properties $prop]
+		}
+		
+		proc get {} {
+			variable properties
+			return $properties
+		}
+		
+		proc validate_length { length } {
+			return [expr {$length in {{} list} || [string is integer $length]}]
+		}
+
+		proc validate_nonempty_string { text } {
+			return [expr {$text ne ""}]
+		}
+
+		proc validate_boolean { bool } {
+			return [expr {[string is true -strict $bool] || [string is false -strict $bool]}]
+		}
+
+		proc validate_category { valid_values category } {
+			return [expr {$category in $valid_values}]
+		}
+		
+	}
+	
+	proc add { field args } {
+		variable dd		
+		if { [dict exists $dd $field] } {
+			msg -WARNING [namespace current] "add: field name '$field' already exists in the data dictionary, duplicates not allowed"
+			return
+		}		
+		if { [llength $args] == 1 } {
+			set args [lindex $args 0]
+		}
+		array set arr_args $args
+		
+		set props {}
+		foreach prop [dictionary properties] {
+			if { [info exists arr_args($prop)] } {
+				lappend props $prop $arr_args($prop)
+			} else {
+				lappend props $prop {}
+			}
+		}
+		
+		dict set dd $field [dict create {*}$props]
+	}
+
+	# If no properties are specified in 'args', return a Tcl dict with all the properties.
+	# If 'args' is given, return a list with the values of the requested properties.
+	proc get { field args } {
+		variable dd
+		if { ![dict exists $dd $field] } {
+			msg -WARNING [namespace current] "get: field name '$field' not found in the data dictionary"
+			return {}
+		} 
+		
+		set field_dd [dict get $dd $field]
+		if { $args eq "" } {
+			return $field_dd
+		} else {
+			if { [llength $args] == 1 } {
+				set args [lindex $args 0]
+			}
+			set alist {}
+			foreach fn $args {
+				lappend alist [dict get $field_dd $fn]
+			}
+			return $alist
+		}
+	}
+	
+	proc fields { args } {
+		variable dd
+		set glob_pattern ""
+		if { [llength $args] > 0 && [string range [lindex $args 0] 0 0] ne "-" } {
+			set fields [dict keys $dd [pop args]]
+		} else {
+			set fields [dict keys $dd]
+		}
+		
+		for { set i 0 } { $i < [llength $args] } { incr i 2 } {
+			set filter_field [lindex $args $i]
+			if { [string range $filter_field 0 0] eq "-" } {
+				set filter_field [string range $filter_field 1 end]
+			}
+			set filter_values [lindex $args [expr {$i+1}]]
+			
+			if { [metadata dictionary exists $filter_field] } {
+				set filtered_fields {}
+				foreach fn $fields {
+					if { [metadata get $fn $filter_field] in $filter_values } {
+						lappend filtered_fields $fn
+					}
+				}				
+				set fields $filtered_fields
+			} else {
+				msg -WARNING [namespace current] "fields: metadata dictionary filter field '$filter_field' not found"
+			}
+		}
+		
+		return $fields
+	}
+	
+	proc exists { field } {
+		variable dd
+		return [dict exists $dd $field]
+	}	
+	
+	proc validate { field value } {
+		
+	}
+}

--- a/de1plus/misc.tcl
+++ b/de1plus/misc.tcl
@@ -115,6 +115,8 @@ proc make_de1_dir {srcdir destdirs} {
         gui.tcl *
         history_viewer.tcl *
         dui.tcl *
+		metadata.tcl *
+		app_metadata.tcl *
         machine.tcl *
         utils.tcl *
         main.tcl *

--- a/de1plus/pkgIndex.tcl
+++ b/de1plus/pkgIndex.tcl
@@ -18,3 +18,4 @@ package ifneeded de1_de1 1.4 [list source [file join "./" de1_de1.tcl]]
 package ifneeded de1_device_scale 1.5 [list source [file join "./" device_scale.tcl]]
 
 package ifneeded de1_history_viewer 1.1 [list source [file join "./" history_viewer.tcl]]
+package ifneeded de1_metadata 1.0 [list source [file join "./" metadata.tcl]]

--- a/de1plus/utils.tcl
+++ b/de1plus/utils.tcl
@@ -1,6 +1,7 @@
 package provide de1_utils 1.1
 
 package require de1_logging 1.0
+package require de1_metadata 1.0
 
 proc setup_environment {} {
 	global android
@@ -131,6 +132,10 @@ proc setup_environment {} {
         font create Helv_30 -family $regularfont -size [expr {int($fontm * 72)}]
 	}
 	
+	metadata init
+	source "app_metadata.tcl"
+	init_app_metadata
+			
 	after 60000 schedule_minute_task
 
 	return


### PR DESCRIPTION
An initial simple implementation of a metadata package as described [on Basecamp](https://3.basecamp.com/3671212/buckets/7351439/messages/3762617806):

Having a data dictionary for the application fields in place should help in several ways:
- **Avoid code repetition**. Many values, such as lower and upper limits for variables, are currently hardcoded in many places in the code, which leads to problems (how often we've seen "probably that bug is due to a GUI control somewhere setting a limit on the variable, which is constraining it everywhere"?). Having a standard way to retrieve those values should help mitigate the problem. And anything that avoids code repetitition ("copy & paste") helps code maintenance.
- **Provide a standard way to add new fields**. Adding new data has proved to be a source of bugs, as often they are not reset properly. This is a problem specially when the data is introduced by skins and plugins/extensions, as even if the skin resets the data, its last defined value may be persisted forever in the shot files and in settings.tdb when the user changes the skin or disables the plugin. Base code may also be affected by these problems, though, as happened with the introduction of the "beverage_type" field.
- **Automate many coding tasks**. Creating code that reads the data dictionary and buils a GUI for them, or adds database fields dynamically, makes it easier to build some powerful features. This is extensivelly used by the SDB and DYE plugins, and would be a prerequisite to incorporate SDB functionallity in the base app.
- **Make fields self-documenting**

This implements the proposed API and is only missing validation functionallity.
Example metadata for shot description fields (as used by the DYE extension) are included in app_metadata.tcl as an example. If accepted, new fields will be added in successive versions to cover app needs.