### PR TITLE
Fix empty spaces bug in DUI fonts or images folders

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -2945,9 +2945,6 @@ namespace eval ::dui {
 		
 		proc add_dirs { args } {
 			variable font_dirs
-			if { [llength $args] == 1 } {
-				set args [lindex $args 0]
-			}
 			
 			foreach dir $args {
 				set dir [file normalize $dir]
@@ -3182,9 +3179,6 @@ namespace eval ::dui {
 				
 		proc add_dirs { args } {
 			variable img_dirs
-			if { [llength $args] == 1 } {
-				set args [lindex $args 0]
-			}
 			
 			foreach dir $args {
 				set dir [file normalize $dir]


### PR DESCRIPTION
Fixes the bug found by @damian-au that font directories paths added with 'dui font add_dir' failed to be added correctly if the path contained spaces. Same happened with image folders added with 'dui image add_dir'.