### PR TITLE
Increase drink_tds upper limit from 14 to 25

### DIFF
--- a/de1plus/app_metadata.tcl
+++ b/de1plus/app_metadata.tcl
@@ -211,7 +211,7 @@ proc init_app_metadata {} {
 		propagate 0
 		data_type number
 		min 0.0
-		max 15.0
+		max 25.0
 		default 8.0
 		smallincrement 0.01
 		bigincrement 0.1

--- a/de1plus/skins/Insight/scentone.tcl
+++ b/de1plus/skins/Insight/scentone.tcl
@@ -220,7 +220,7 @@ if {$::settings(has_refractometer) == 1 || $::settings(has_scale) == 1} {
 
 	if {$::settings(has_refractometer) == 1} {
 		add_de1_text "describe_espresso" 1630 670 -text [translate "Total dissolved solids (TDS)"] -font Helv_8 -fill "#7f879a" -anchor "nw" -width 800 -justify "left"
-		add_de1_widget "describe_espresso" scale 1630 730 {} -to 14 -from 0 -background #e4d1c1 -showvalue 0 -borderwidth 1 -bigincrement 10 -resolution 0.1 -length [rescale_x_skin 850]  -width [rescale_y_skin 140] -variable ::settings(drink_tds) -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command {} -foreground #FFFFFF -troughcolor $slider_trough_color2 -borderwidth 0  -highlightthickness 0 -orient horizontal 
+		add_de1_widget "describe_espresso" scale 1630 730 {} -to 25 -from 0 -background #e4d1c1 -showvalue 0 -borderwidth 1 -bigincrement 10 -resolution 0.1 -length [rescale_x_skin 850]  -width [rescale_y_skin 140] -variable ::settings(drink_tds) -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command {} -foreground #FFFFFF -troughcolor $slider_trough_color2 -borderwidth 0  -highlightthickness 0 -orient horizontal 
 		add_de1_variable "describe_espresso" 2480 870 -text "" -font Helv_8 -fill "#4e85f4" -anchor "ne" -width 600 -justify "left" -textvariable {[return_percent_off_if_zero $::settings(drink_tds)]}
 
 		add_de1_text "describe_espresso" 1630 900 -text [translate "Extraction yield (EY)"] -font Helv_8 -fill "#7f879a" -anchor "nw" -width 800 -justify "left"


### PR DESCRIPTION
This increases the upper limit for the drink_tds shot variable from 14 to 25%, as requested by some users. Seems that strong ristrettos can achieve values around 20%, so 25% seems a safe upper limit.

This required changing the limit in the scale widget of the "scentone" file, as it bounds to $::settings(drink_tds) and higher values are auto-set to the upper limit due to this binding. Also modified in the new app metadata. I've done the same change in SDB so that it's also acknowledged in DYE.

