### PR TITLE
Dui and Metadata updates

### DIFF
--- a/de1plus/app_metadata.tcl
+++ b/de1plus/app_metadata.tcl
@@ -27,7 +27,7 @@ proc init_app_metadata {} {
 	metadata dictionary add default_dui_widget [list validate_category {entry text listbox dcombobox dcheckbox drater dclicker}]	
 	
 	# Define the actual fields
-	metadata add profile_title {
+	metadata add profile_title end {
 		domain {profile shot}
 		owner_type base
 		name "Profile title"
@@ -40,7 +40,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget dcombobox
 	}
-	metadata add bean_brand {
+	metadata add bean_brand end {
 		domain shot
 		category description
 		section beans
@@ -56,7 +56,7 @@ proc init_app_metadata {} {
 		length list
 		default_dui_widget dcombobox
 	}
-	metadata add bean_type {
+	metadata add bean_type end {
 		domain shot
 		category description
 		section beans
@@ -72,7 +72,7 @@ proc init_app_metadata {} {
 		length list
 		default_dui_widget dcombobox
 	}
-	metadata add roast_date {
+	metadata add roast_date end {
 		domain shot
 		category description
 		section beans
@@ -88,7 +88,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget entry
 	}
-	metadata add roast_level {
+	metadata add roast_level end {
 		domain shot
 		category description
 		section beans
@@ -104,7 +104,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget dcombobox
 	}
-	metadata add bean_notes {
+	metadata add bean_notes end {
 		domain shot
 		category description
 		section beans
@@ -120,7 +120,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget text
 	}		
-	metadata add grinder_model {
+	metadata add grinder_model end {
 		domain shot
 		category description
 		section equipment
@@ -136,7 +136,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget dcombobox
 	}
-	metadata add grinder_setting {
+	metadata add grinder_setting end {
 		domain shot
 		category description
 		section equipment
@@ -152,7 +152,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget dcombobox
 	}
-	metadata add grinder_dose_weight {
+	metadata add grinder_dose_weight end {
 		domain shot
 		category description
 		section extraction
@@ -175,7 +175,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget dclicker
 	}
-	metadata add drink_weight {
+	metadata add drink_weight end {
 		domain shot
 		category description
 		section extraction
@@ -198,7 +198,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget dclicker
 	}
-	metadata add drink_tds {
+	metadata add drink_tds end {
 		domain shot
 		category description
 		section extraction
@@ -221,7 +221,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget dclicker
 	}
-	metadata add drink_ey {
+	metadata add drink_ey end {
 		domain shot
 		category description
 		section extraction
@@ -244,7 +244,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget dclicker
 	}
-	metadata add espresso_notes {
+	metadata add espresso_notes end {
 		domain shot
 		category description
 		section extraction
@@ -260,7 +260,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget text
 	}	
-	metadata add espresso_enjoyment {
+	metadata add espresso_enjoyment end {
 		domain shot
 		category description
 		section tasting
@@ -282,7 +282,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget drater
 	}
-	metadata add scentone {
+	metadata add scentone end {
 		domain shot
 		category description
 		section tasting
@@ -298,7 +298,7 @@ proc init_app_metadata {} {
 		length list
 		default_dui_widget {}
 	}	
-	metadata add my_name {
+	metadata add my_name end {
 		domain shot
 		category description
 		section people
@@ -314,7 +314,7 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget dcombobox
 	}
-	metadata add beverage_type {
+	metadata add beverage_type end {
 		domain profile
 		category machine?
 		section drink

--- a/de1plus/app_metadata.tcl
+++ b/de1plus/app_metadata.tcl
@@ -234,8 +234,8 @@ proc init_app_metadata {} {
 		propagate 0
 		data_type number
 		min 0.0
-		max 15.0
-		default 8.0
+		max 30.0
+		default 18.0
 		smallincrement 0.01
 		bigincrement 0.1
 		n_decimals 2
@@ -244,11 +244,27 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget dclicker
 	}
-	metadata add espresso_enjoyment {
+	metadata add espresso_notes {
 		domain shot
 		category description
 		section extraction
 		subsection tasting
+		owner_type base
+		name "Espresso note"
+		name_plural "Espresso notes"
+		short_name "Note" 
+		short_name_plural "Notes"
+		propagate 0
+		data_type long_text
+		required 0
+		length 1
+		default_dui_widget text
+	}	
+	metadata add espresso_enjoyment {
+		domain shot
+		category description
+		section tasting
+		subsection ""
 		owner_type base
 		name "Enjoyment (0-100)"
 		name_plural "Enjoyment"
@@ -269,8 +285,8 @@ proc init_app_metadata {} {
 	metadata add scentone {
 		domain shot
 		category description
-		section extraction
-		subsection tasting
+		section tasting
+		subsection ""
 		owner_type base
 		name "Scentone flavours"
 		name_plural "Scentone flavours"
@@ -282,22 +298,6 @@ proc init_app_metadata {} {
 		length list
 		default_dui_widget {}
 	}	
-	metadata add espresso_notes {
-		domain shot
-		category description
-		section extraction
-		subsection tasting
-		owner_type base
-		name "Espresso note"
-		name_plural "Espresso notes"
-		short_name "Note" 
-		short_name_plural "Notes"
-		propagate 0
-		data_type long_text
-		required 0
-		length 1
-		default_dui_widget text
-	}
 	metadata add my_name {
 		domain shot
 		category description

--- a/de1plus/app_metadata.tcl
+++ b/de1plus/app_metadata.tcl
@@ -266,6 +266,22 @@ proc init_app_metadata {} {
 		length 1
 		default_dui_widget drater
 	}
+	metadata add scentone {
+		domain shot
+		category description
+		section extraction
+		subsection tasting
+		owner_type base
+		name "Scentone flavours"
+		name_plural "Scentone flavours"
+		short_name "Scentone" 
+		short_name_plural "Scentone"
+		propagate 0
+		data_type complex
+		required 0
+		length list
+		default_dui_widget {}
+	}	
 	metadata add espresso_notes {
 		domain shot
 		category description

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -4244,14 +4244,32 @@ namespace eval ::dui {
 				# TBD: Pass $args to load actions???
 				foreach action [actions $page_to_show load] {
 					lappend action $page_to_hide $page_to_show
-					uplevel #0 $action
 					#eval $action
+					set action_result [uplevel #0 $action]
+					if { $action_result ne "" && $action_result != 1 } {
+						if { $action_result == 0 } {
+							msg -NOTICE [namespace current] "loading of page '$page_to_show' interrupted"
+							return
+						} else {
+							msg -NOTICE [namespace current] "CHANGING page_to_show from '$page_to_show' to '$action_result'"
+							set page_to_show $action_result	
+						} 
+					}
 				}
 				if { $show_ns ne "" && [info procs ${show_ns}::load] ne "" } {
-					set page_loaded [${show_ns}::load $page_to_hide $page_to_show {*}$args]
-					if { ![string is true $page_loaded] } {
-						# Interrupt the loading: don't show the new page
-						return
+					set action_result [${show_ns}::load $page_to_hide $page_to_show {*}$args]
+#					if { ![string is true $page_loaded] } {
+#						# Interrupt the loading: don't show the new page
+#						return
+#					}
+					if { $action_result ne "" && $action_result != 1 } {
+						if { $action_result == 0 } {
+							msg -NOTICE [namespace current] "loading of page '$page_to_show' interrupted"
+							return
+						} else {
+							msg -NOTICE [namespace current] "CHANGING page_to_show from '$page_to_show' to '$action_result'"
+							set page_to_show $action_result	
+						} 
 					}
 				}
 			}

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -4600,7 +4600,7 @@ namespace eval ::dui {
 	namespace eval item {
 		namespace export add get get_widget config cget enable_or_disable enable disable \
 			show_or_hide show hide add_image_dirs image_dirs listbox_get_selection listbox_set_selection \
-			relocate_text_wrt
+			relocate_text_wrt moveto
 		namespace ensemble create
 	
 		variable sliders
@@ -4855,6 +4855,37 @@ namespace eval ::dui {
 		proc sound_dirs {} {
 			variable sound_dirs
 			return $sound_dirs
+		}
+		
+		# Moves canvas items or compounds to a new screen location
+		proc moveto { page_or_id_or_widget tag x y } {
+			set can [dui canvas]
+			set tag [lindex $tag 0]
+			set items [dui item get $page_or_id_or_widget $tag]
+			
+			if { [string range $tag end-1 end] eq "*" } {
+				set refitem [dui item get $page_or_id_or_widget [string range $tag 0 end-1]]
+			} else {
+				set refitem [lindex $items end]
+			}
+			if { $refitem eq "" } {
+				msg -WARNING [namespace current] "moveto: cannot locate reference item ${page_or_id_or_widget}::${tag}"
+				return
+			}
+			
+			lassign [$can coords $refitem] rx0 ry0 rx1 ry1
+			foreach id $items {
+				lassign [$can coords $id] x0 y0 x1 y1
+				set nx0 [expr {$x+$x0-$rx0}]
+				set ny0 [expr {$y+$y0-$ry0}]
+				if { $x1 eq "" || $y1 eq "" } {
+					$can coords $id $nx0 $ny0
+				} else {
+					set nx1 [expr {$nx0+($x1-$x0)}]
+					set ny1 [expr {$ny0+($y1-$y0)}]
+					$can coords $id $nx0 $ny0 $nx1 $ny1 
+				}
+			}
 		}
 		
 		# Moves a text canvas item with respect to another item or widget, i.e. to a position relative to another one.

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -3535,7 +3535,7 @@ namespace eval ::dui {
 			}
 			# Main tags must be unique per-page.
 			foreach page $pages {
-				if { [dui page has_item $page $main_tag] ne "" } {
+				if { [dui page has_item $page $main_tag] } {
 					set msg "process_tags_and_var: main tag '$main_tag' already exists in page '$page', duplicates are not allowed"
 					msg -ERROR [namespace current] $msg
 					info_page $msg
@@ -4463,8 +4463,9 @@ namespace eval ::dui {
 		proc has_item { page tag } {
 			if { [llength $page] > 1 } {
 				set page [lindex $page 0]
-			}			
-			return [[dui canvas] find withtag $tag&&p:$page]
+			}
+			set items [[dui canvas] find withtag $tag&&p:$page]
+			return [expr {$items ne ""}]
 		}
 		
 		# Keep track of what labels are displayed in what pages. This is done through the "p:<page_name>" canvas tags 

--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -808,17 +808,25 @@ proc reset_gui_starting_espresso {} {
 	set ::de1(final_espresso_weight) 0
 
 	############
-	# clear any description of the previous espresso
-	set ::settings(scentone) ""
-	set ::settings(espresso_enjoyment) 0
-
 	# this sets the time the espresso starts, used for recording this espresso to a history file
 	set ::settings(espresso_clock) [clock seconds]
 
-	set ::settings(espresso_notes) ""
-	set ::settings(drink_tds) 0
-	set ::settings(drink_weight) 0
-	set ::settings(drink_ey) 0
+	# clear any description of the previous espresso
+#	set ::settings(scentone) ""
+#	set ::settings(espresso_enjoyment) 0	
+#	set ::settings(espresso_notes) ""
+#	set ::settings(drink_tds) 0
+#	set ::settings(drink_weight) 0
+#	set ::settings(drink_ey) 0
+	foreach field [metadata fields -domain shot -category description -propagate 0] {
+		set data_type [metadata get $field data_type]
+		if { $data_type eq "number" } {
+			set ::settings($field) 0
+		} else {
+			set ::settings($field) {}
+		}
+	}
+	
 	############
 
 

--- a/de1plus/metadata.tcl
+++ b/de1plus/metadata.tcl
@@ -87,7 +87,7 @@ namespace eval ::metadata {
 		
 	}
 		
-	proc add { field args } {
+	proc add { field after args } {
 		variable dd		
 		if { [dict exists $dd $field] } {
 			msg -WARNING [namespace current] "add: field name '$field' already exists in the data dictionary, duplicates not allowed"
@@ -107,7 +107,28 @@ namespace eval ::metadata {
 			}
 		}
 		
-		dict set dd $field [dict create {*}$props]
+		if { $after eq "" || [string tolower $after] eq "end" } {
+			::set after "end"
+		} elseif { $after ne "start" && ![dict exists $dd $after] } {
+			msg -WARNING [namespace current] "add: after field '$field' not found in the data dictionary, adding after end"
+			set after "end"
+		}
+		
+		if { $after eq "end" } {
+			dict set dd $field [dict create {*}$props]
+		} else {
+			::set new_dd [dict create]
+			if { [string tolower $after] eq "start" } {
+				dict set new_dd $field [dict create {*}$props]
+			}
+			foreach key [dict keys $dd] {
+				dict set new_dd $key [dict get $dd $key]
+				if { $key eq $after } {
+					dict set new_dd $field [dict create {*}$props]
+				}
+			}
+			::set dd $new_dd
+		}
 		return 1
 	}
 

--- a/de1plus/metadata.tcl
+++ b/de1plus/metadata.tcl
@@ -5,30 +5,39 @@ package require de1_updater 1.1
 package require de1_utils 1.1
 
 namespace eval ::metadata {
-	namespace export *
+	namespace export init dictionary add set get fields exists validate
 	namespace ensemble create
 
 	# Data Dictionary
 	variable dd
-	set dd [dict create]
+	::set dd [dict create]
 	
 	# Invoking 'init' resets all existing metadata
 	proc init { } {
 		variable dd		
 		metadata dictionary init
-		set dd [dict create]
+		::set dd [dict create]
 	}
 
+	# Ensures a new property gets empty slots on each field
+	proc _add_property { prop } {
+		variable dd
+		foreach field [dict keys $dd] {
+			dict set dd $field $prop {}
+		}
+		return {}
+	}
+	
 	namespace eval dictionary  {
 		namespace export *
 		namespace ensemble create
 		
 		variable properties
-		set properties [dict create]
+		::set properties [dict create]
 		
 		proc init {} {
 			variable properties
-			set properties [dict create]
+			::set properties [dict create]
 		}
 		
 		proc add { prop {vcmd {}} } {
@@ -37,10 +46,11 @@ namespace eval ::metadata {
 				msg -WARNING [namespace current] "add: property name '$prop' already exists in the metadata data dictionary, duplicates not allowed"
 				return
 			}
-			set first_cmd [lindex $$vcmd 0]
+			::set first_cmd [lindex $$vcmd 0]
 			if { [string is wordchar -strict $first_cmd] && [namespace which -command [namespace current]::$first_cmd] ne "" } {
 				lset vcmd 0 0 [namespace current]::$first_cmd
 			}
+			metadata::_add_property $prop
 			dict set properties $prop $vcmd
 		}
 
@@ -76,19 +86,19 @@ namespace eval ::metadata {
 		}
 		
 	}
-	
+		
 	proc add { field args } {
 		variable dd		
 		if { [dict exists $dd $field] } {
 			msg -WARNING [namespace current] "add: field name '$field' already exists in the data dictionary, duplicates not allowed"
 			return 0
 		}		
-		if { [llength $args] == 1 } {
-			set args [lindex $args 0]
+		if { [llength $args] == 1 && [llength [lindex $args 0]] > 1 } {
+			::set args [lindex $args 0]
 		}
 		array set arr_args $args
 		
-		set props {}
+		::set props {}
 		foreach prop [dictionary properties] {
 			if { [info exists arr_args($prop)] } {
 				lappend props $prop $arr_args($prop)
@@ -101,6 +111,31 @@ namespace eval ::metadata {
 		return 1
 	}
 
+	proc set { field args } {
+		variable dd		
+		if { ![dict exists $dd $field] } {
+			msg -ERROR [namespace current] "set: field name '$field' not found in data dictionary"
+			return 0
+		}		
+		if { [llength $args] == 1 && [llength [lindex $args 0]] > 1 } {
+			::set args [lindex $args 0]
+		}
+		array set arr_args $args
+		
+		::set result 0
+		::set props {}
+		foreach prop [array names arr_args] {
+			if { [metadata dictionary exists $prop] } {
+				dict set dd $field $prop $arr_args($prop)
+				::set result 1
+			} else {
+				msg -ERROR [namespace current] "set: property name '$prop' not found in metadata dictionary"
+			}
+		}
+		
+		return $result
+	}
+		
 	# If no properties are specified in 'args', return a Tcl dict with all the properties.
 	# If 'args' is given, return a list with the values of the requested properties.
 	proc get { field args } {
@@ -110,14 +145,14 @@ namespace eval ::metadata {
 			return {}
 		} 
 		
-		set field_dd [dict get $dd $field]
+		::set field_dd [dict get $dd $field]
 		if { $args eq "" } {
 			return $field_dd
 		} else {
 			if { [llength $args] == 1 } {
-				set args [lindex $args 0]
+				::set args [lindex $args 0]
 			}
-			set alist {}
+			::set alist {}
 			foreach fn $args {
 				lappend alist [dict get $field_dd $fn]
 			}
@@ -127,28 +162,28 @@ namespace eval ::metadata {
 	
 	proc fields { args } {
 		variable dd
-		set glob_pattern ""
+		::set glob_pattern ""
 		if { [llength $args] > 0 && [string range [lindex $args 0] 0 0] ne "-" } {
-			set fields [dict keys $dd [pop args]]
+			::set fields [dict keys $dd [pop args]]
 		} else {
-			set fields [dict keys $dd]
+			::set fields [dict keys $dd]
 		}
 		
-		for { set i 0 } { $i < [llength $args] } { incr i 2 } {
-			set filter_field [lindex $args $i]
+		for { ::set i 0 } { $i < [llength $args] } { incr i 2 } {
+			::set filter_field [lindex $args $i]
 			if { [string range $filter_field 0 0] eq "-" } {
-				set filter_field [string range $filter_field 1 end]
+				::set filter_field [string range $filter_field 1 end]
 			}
-			set filter_values [lindex $args [expr {$i+1}]]
+			::set filter_values [lindex $args [expr {$i+1}]]
 			
 			if { [metadata dictionary exists $filter_field] } {
-				set filtered_fields {}
+				::set filtered_fields {}
 				foreach fn $fields {
 					if { [any_in_list {*}[metadata get $fn $filter_field] $filter_values] } {
 						lappend filtered_fields $fn
 					}
 				}
-				set fields $filtered_fields
+				::set fields $filtered_fields
 			} else {
 				msg -WARNING [namespace current] "fields: metadata dictionary filter field '$filter_field' not found"
 			}

--- a/de1plus/metadata.tcl
+++ b/de1plus/metadata.tcl
@@ -81,7 +81,7 @@ namespace eval ::metadata {
 		variable dd		
 		if { [dict exists $dd $field] } {
 			msg -WARNING [namespace current] "add: field name '$field' already exists in the data dictionary, duplicates not allowed"
-			return
+			return 0
 		}		
 		if { [llength $args] == 1 } {
 			set args [lindex $args 0]
@@ -98,6 +98,7 @@ namespace eval ::metadata {
 		}
 		
 		dict set dd $field [dict create {*}$props]
+		return 1
 	}
 
 	# If no properties are specified in 'args', return a Tcl dict with all the properties.
@@ -143,10 +144,10 @@ namespace eval ::metadata {
 			if { [metadata dictionary exists $filter_field] } {
 				set filtered_fields {}
 				foreach fn $fields {
-					if { [metadata get $fn $filter_field] in $filter_values } {
+					if { [any_in_list {*}[metadata get $fn $filter_field] $filter_values] } {
 						lappend filtered_fields $fn
 					}
-				}				
+				}
 				set fields $filtered_fields
 			} else {
 				msg -WARNING [namespace current] "fields: metadata dictionary filter field '$filter_field' not found"

--- a/de1plus/utils.tcl
+++ b/de1plus/utils.tcl
@@ -1687,6 +1687,32 @@ proc list_remove_element {list toremove} {
     return $newlist
 }
 
+proc any_in_list { x list } {
+	if { $x eq "" } {
+		return 0
+	}	
+	set match 0
+	set i 0
+	while { !$match && $i < [llength $x] } {
+		set match [expr {[lindex $x $i] in $list}]
+		incr i
+	}
+	return $match
+}
+
+proc all_in_list { x list } {
+	if { $x eq "" } {
+		return 0
+	}
+	set match 1
+	set i 0
+	while { $match && $i < [llength $x] } {
+		set match [expr {[lindex $x $i] in $list}]
+		incr i
+	}
+	return $match
+}
+
 proc web_browser {url} {
     msg -INFO "Browser '$url'"
 	if { $::android == 1 } {

--- a/documentation/decent_user_interface.md
+++ b/documentation/decent_user_interface.md
@@ -586,7 +586,7 @@ page is actually shown. This proc is normally used to initialize page data, such
 
 Though receiving the page to be shown as an argument on the **load** and **show** namespace commands may seem unnecessary, it is required when a single namespace is used for several related pages. Same argument for passing the name of the page to be hidden to the **hide** namespace command.
 
-A page namespace **load** command must return a boolean value. This is used to optionally interrupt the loading of the page (if the return value casts to  _false_ ).
+A page namespace **load** command must return either 0, 1, or a page name. This is used to optionally interrupt the loading of the page (if the return value is 0), or to diverge the flow to another page (if the return value is a new page name).
 
 ##### show 
 Takes place whenever the <a href="#dui_page_load">dui page load</a> or <a href="#dui_page_show">dui page show</a> commands are run,  _after_  the page is actually shown. This event is normally used to initialize the page GUI elements (e.g. show/hide or enable/disable some items depending on the state).

--- a/documentation/decent_user_interface.md
+++ b/documentation/decent_user_interface.md
@@ -929,6 +929,13 @@ _show_ can be any value that is coerced to a boolean (1/0, true/false, etc.)
 >Selects the items matching the  _selected_  string in the specified listbox widget. If a  _values_  list is provided,  _selected_  is matched against  _values_  instead of the list values. If  _reset_current_  is 1 (or any other value that is coerced to a boolean  _true_ ), the current selection is reset first (this is only relevant with listboxes that accept multiple selections).
 
 
+<a name="dui_item_moveto"></a>
+
+**dui item moveto**  _page_or_id_or_widget tag x y_
+
+>Moves items to a new screen location.  _x_  and  _y_  give the new top-left coordinates. If  _tag_  selects all items in a compound (ends with a "*" character), all individual items of the compound will be moved, preserving their relative positions (use this to move, for example, dbuttons).
+
+
 <a name="dui_add"></a>
 
 #### `dui add`


### PR DESCRIPTION
This adds several new features to both the DUI and Metadata packages, many of them in preparation for DYE v3:

**Metadata:**
- New `metadata::set` command to modify existing metadata 
- New argument `after` for command `metadata:add`, to allow adding fields in the desired order.
- drink_ey gets new upper limit 'max' and new 'default', as it incorrectly had those of TDS
- If a new dictionary property is added, it is added to all existing fields, with empty string as default value.
- Add scentone field

**DUI:**
- New command `dui::item::moveto` allows to move visual items, and specially compounds, at once, to a new screen position.
- All 3 forms of load page actions now can modify the page being loaded (before only the namespace load command could do it)
- Add validation of fields with data_type=date

**Other changes in the base code:**
- proc reset_gui_starting_espresso in machine.tcl now resets description fields that must not be propagated from shot to shot using the metadata dictionary.
- 2 new utility functions `any_in_list` and `all_in_list` in utils.tcl, to check whether any or all elements in a list are available in another list.
