### PR TITLE
Potential fix for issue #164.   Upload data only for espresso operations in visualizer_upload plugin

### DIFF
--- a/de1plus/plugins/visualizer_upload/plugin.tcl
+++ b/de1plus/plugins/visualizer_upload/plugin.tcl
@@ -221,7 +221,10 @@ namespace eval ::plugins::${plugin_name} {
     }
 
     proc async_dispatch {old new} {
-        after 100 ::plugins::visualizer_upload::uploadShotData
+        # Prevent uploading of data if last flow was HotWater or HotWaterRinse
+        if { $old eq "Espresso" } {
+            after 100 ::plugins::visualizer_upload::uploadShotData
+        }
     }
 
     proc browse {} {


### PR DESCRIPTION
Here is a small fix for preventing the visualizer upload plugin from running after HotWater and HotWaterRinse operations.  This will gate the subsequent upload function to execute only when previous state is Espresso.