### PR TITLE
Make limits&parameters for numeric fields in scentone.tcl come from metadata

### DIFF
--- a/de1plus/skins/Insight/scentone.tcl
+++ b/de1plus/skins/Insight/scentone.tcl
@@ -115,8 +115,9 @@ set slider_trough_color2 #f3f3f3
 
 
 # from http://www.iconarchive.com/show/shiny-smiley-icons-by-iconicon.html
+lassign [metadata get espresso_enjoyment n_decimals min max bigincrement] n_dec min max biginc
 add_de1_text "describe_espresso" 80 360 -text [translate "Enjoyment"] -font Helv_8_bold -fill "#7f879a" -anchor "nw" -width 800 -justify "left"
-	add_de1_widget "describe_espresso" scale 300 450 {} -to 100 -from 0 -background #e4d1c1 -showvalue 0 -borderwidth 1 -bigincrement 10 -resolution 1 -length [rescale_x_skin 1000]  -width [rescale_y_skin 150] -variable ::settings(espresso_enjoyment) -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command {} -foreground #FFFFFF -troughcolor $slider_trough_color1 -borderwidth 0  -highlightthickness 0 -orient horizontal 
+	add_de1_widget "describe_espresso" scale 300 450 {} -to $max -from $min -background #e4d1c1 -showvalue 0 -borderwidth 1 -bigincrement $biginc -resolution 1 -length [rescale_x_skin 1000]  -width [rescale_y_skin 150] -variable ::settings(espresso_enjoyment) -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command {} -foreground #FFFFFF -troughcolor $slider_trough_color1 -borderwidth 0  -highlightthickness 0 -orient horizontal 
 	add_de1_variable "describe_espresso" 1300 600 -text "" -font Helv_8 -fill "#4e85f4" -anchor "ne" -width 600 -justify "left" -textvariable {$::settings(espresso_enjoyment)}
 
 
@@ -155,7 +156,9 @@ add_de1_text "describe_espresso2" 80 360 -text [translate "Grinder"] -font Helv_
 
 	#set slider_trough_color2 #EAEAEA
 	add_de1_text "describe_espresso2" 540 620 -text [translate "Dose weight"] -font Helv_8 -fill "#7f879a" -anchor "ne" -width 800 -justify "center"
-	add_de1_widget "describe_espresso2" scale 550 610 {} -to 30 -from 0 -background #e4d1c1 -showvalue 0 -borderwidth 1 -bigincrement 1 -resolution 0.1 -length [rescale_x_skin 630]  -width [rescale_y_skin 150] -variable ::settings(grinder_dose_weight) -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command {} -foreground #FFFFFF -troughcolor $slider_trough_color2 -borderwidth 0  -highlightthickness 0 -orient horizontal 
+	
+	lassign [metadata get grinder_dose_weight n_decimals min max bigincrement] n_dec min max biginc
+	add_de1_widget "describe_espresso2" scale 550 610 {} -to $max -from $min -background #e4d1c1 -showvalue 0 -borderwidth 1 -bigincrement $biginc -resolution [expr {1.0/(10.0*$n_dec)}] -length [rescale_x_skin 630]  -width [rescale_y_skin 150] -variable ::settings(grinder_dose_weight) -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command {} -foreground #FFFFFF -troughcolor $slider_trough_color2 -borderwidth 0  -highlightthickness 0 -orient horizontal 
 	add_de1_variable "describe_espresso2" 1160 760 -text "" -font Helv_8 -fill "#4e85f4" -anchor "ne" -width 600 -justify "left" -textvariable {[return_stop_at_weight_measurement_precise $::settings(grinder_dose_weight)]}
 
 
@@ -214,17 +217,24 @@ if {$::settings(has_refractometer) == 1 || $::settings(has_scale) == 1} {
 }
 
 	add_de1_text "describe_espresso" 1630 440 -text [translate "Weight"] -font Helv_8 -fill "#7f879a" -anchor "nw" -width 800 -justify "left"
-	add_de1_widget "describe_espresso" scale 1630 500 {} -to 100 -from 0 -background #e4d1c1 -showvalue 0 -borderwidth 1 -bigincrement 10 -resolution 0.1 -length [rescale_x_skin 850]  -width [rescale_y_skin 140] -variable ::settings(drink_weight) -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command {} -foreground #FFFFFF -troughcolor $slider_trough_color2 -borderwidth 0  -highlightthickness 0 -orient horizontal 
+	
+	lassign [metadata get drink_weight n_decimals min max bigincrement] n_dec min max biginc
+	add_de1_widget "describe_espresso" scale 1630 500 {} -to $max -from $min -background #e4d1c1 -showvalue 0 -borderwidth 1 -bigincrement $biginc -resolution [expr {1.0/(10.0*$n_dec)}] -length [rescale_x_skin 850]  -width [rescale_y_skin 140] -variable ::settings(drink_weight) -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command {} -foreground #FFFFFF -troughcolor $slider_trough_color2 -borderwidth 0  -highlightthickness 0 -orient horizontal 
+	
 	add_de1_variable "describe_espresso" 2480 640 -text "" -font Helv_8 -fill "#4e85f4" -anchor "ne" -width 600 -justify "left" -textvariable {[return_shot_weight_measurement $::settings(drink_weight)]}
 	#add_de1_variable "describe_espresso" 2480 640 -text "" -font Helv_8 -fill "#4e85f4" -anchor "ne" -width 600 -justify "left" -textvariable {$::settings(drink_weight)}
 
 	if {$::settings(has_refractometer) == 1} {
 		add_de1_text "describe_espresso" 1630 670 -text [translate "Total dissolved solids (TDS)"] -font Helv_8 -fill "#7f879a" -anchor "nw" -width 800 -justify "left"
-		add_de1_widget "describe_espresso" scale 1630 730 {} -to 25 -from 0 -background #e4d1c1 -showvalue 0 -borderwidth 1 -bigincrement 10 -resolution 0.1 -length [rescale_x_skin 850]  -width [rescale_y_skin 140] -variable ::settings(drink_tds) -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command {} -foreground #FFFFFF -troughcolor $slider_trough_color2 -borderwidth 0  -highlightthickness 0 -orient horizontal 
+		
+		lassign [metadata get drink_tds n_decimals min max bigincrement] n_dec min max biginc
+		add_de1_widget "describe_espresso" scale 1630 730 {} -to $max -from $min -background #e4d1c1 -showvalue 0 -borderwidth 1 -bigincrement $biginc -resolution [expr {1.0/(10.0*$n_dec)}] -length [rescale_x_skin 850]  -width [rescale_y_skin 140] -variable ::settings(drink_tds) -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command {} -foreground #FFFFFF -troughcolor $slider_trough_color2 -borderwidth 0  -highlightthickness 0 -orient horizontal 
 		add_de1_variable "describe_espresso" 2480 870 -text "" -font Helv_8 -fill "#4e85f4" -anchor "ne" -width 600 -justify "left" -textvariable {[return_percent_off_if_zero $::settings(drink_tds)]}
 
 		add_de1_text "describe_espresso" 1630 900 -text [translate "Extraction yield (EY)"] -font Helv_8 -fill "#7f879a" -anchor "nw" -width 800 -justify "left"
-		add_de1_widget "describe_espresso" scale 1630 960 {} -to 30 -from 0 -background #e4d1c1 -showvalue 0 -borderwidth 1 -bigincrement 10 -resolution 0.1 -length [rescale_x_skin 850]  -width [rescale_y_skin 140] -variable ::settings(drink_ey) -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command {} -foreground #FFFFFF -troughcolor $slider_trough_color2 -borderwidth 0  -highlightthickness 0 -orient horizontal 
+		
+		lassign [metadata get drink_ey n_decimals min max bigincrement] n_dec min max biginc
+		add_de1_widget "describe_espresso" scale 1630 960 {} -to $max -from $min -background #e4d1c1 -showvalue 0 -borderwidth 1 -bigincrement $biginc -resolution [expr {1.0/(10.0*$n_dec)}] -length [rescale_x_skin 850]  -width [rescale_y_skin 140] -variable ::settings(drink_ey) -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command {} -foreground #FFFFFF -troughcolor $slider_trough_color2 -borderwidth 0  -highlightthickness 0 -orient horizontal 
 		add_de1_variable "describe_espresso" 2480 1100 -text "" -font Helv_8 -fill "#4e85f4" -anchor "ne" -width 600 -justify "left" -textvariable {[return_percent_off_if_zero $::settings(drink_ey)]}
 	}
 


### PR DESCRIPTION
This replaces the hardcoded values of slider options -from, -to, -bigincrement and -resolution of numeric settings variables in Insight scentone.tcl by the equivalent values looked up in the new metadata dictionary.

With this change, option values are defined in a single place instead of hardcoded all around the code, which facilitates maintenance. DYE also looks up those values in the metadata dictionary.

The settings items affected are `espresso_enjoyment`, `grinder_dose_weight`, `drink_weight`, `drink_tds` and `drink_ey`.

As a side effect, this increases the upper limit of `settings(drink_weight)` from 100 to 500 g. This corrects 2 recently reported bugs:
- Pourover actual final weight could not be logged as it is normally above 100 g ([reported by Mitch Hale](https://3.basecamp.com/3671212/buckets/7351439/messages/3762831315#__recording_3837727303))
- Long espresso shots with a final weight above 100 g would show 100 g on DSx home page instead of the actual scale weight ([reported by JasonC](https://decentforum.com/t/100g-bug/1526)), CC @Damian-AU