### PR TITLE
Make settings(drink_weight) store espresso weight only (not hot water)

### DIFF
--- a/de1plus/device_scale.tcl
+++ b/de1plus/device_scale.tcl
@@ -1002,9 +1002,8 @@ namespace eval ::device::scale::history {
 		}
 
 		set $::device::scale::history::_final_weight_name $cwe
-		set ::settings(drink_weight) [round_to_one_digits $cwe]
+		set ::settings(running_weight) [round_to_one_digits $cwe]
 	}
-
 
 
 
@@ -1436,7 +1435,11 @@ namespace eval ::device::scale::callbacks {
 		}
 	}
 
-
+	proc save_drink_weight {event_dict} {
+		if { [dict get $event_dict previous_state] eq "Espresso" } {
+			set ::settings(drink_weight) [round_to_one_digits $::de1(final_espresso_weight)]
+		}
+	}
 
 	::de1::event::listener::on_major_state_change_add -noidle ::device::scale::callbacks::on_major_state_change
 
@@ -1445,6 +1448,8 @@ namespace eval ::device::scale::callbacks {
 	::de1::event::listener::on_major_state_change_add ::device::scale::saw::on_major_state_change
 
 	::de1::event::listener::after_flow_complete_add ::device::scale::history::stop_recording
+	
+	::de1::event::listener::after_flow_complete_add ::device::scale::callbacks::save_drink_weight
 
 	# -noidle should be close enough for scale's inbuilt timer
 	::de1::event::listener::on_flow_change_add -noidle ::device::scale::callbacks::on_flow_change_manage_timer

--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -416,6 +416,7 @@ array set ::settings {
 	flow_hold_stop_volumetric 100
 	flow_decline_stop_volumetric 100
 	pressure_decline_stop_volumetric 100
+	running_weight 0
 	steam_temperature 160
 	steam_timeout 120
 	skin "default"

--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -1104,7 +1104,7 @@ proc drink_weight_text {} {
 		return ""
 	}
 
-	return [return_weight_measurement [ifexists ::settings(running_weight) 0.0]]
+	return [return_weight_measurement $::settings(running_weight)]
 }
 
 proc dump_stack {args} {

--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -1104,7 +1104,7 @@ proc drink_weight_text {} {
 		return ""
 	}
 
-	return [return_weight_measurement $::settings(drink_weight)]
+	return [return_weight_measurement [ifexists ::settings(running_weight) 0.0]]
 }
 
 proc dump_stack {args} {

--- a/documentation/de1_app_core_shot_cycle_overview.md
+++ b/documentation/de1_app_core_shot_cycle_overview.md
@@ -181,7 +181,7 @@ Updates from the DE1 and scale continue.
 
 Now during preinfusion, the estimate of incremental dispensed water derived from the flow rate in the ShotSample, the number of half-cycles of mains since the last update, and the mains frequency, is added to `$::de1(volume)` and `$::de1(preinfusion_volume)`
 
-The scale begins to update the drink weight to `$::de1(final_espresso_weight)` and `$::settings(drink_weight)` During flow, the default implementation is track the weight estimate directly.
+The scale begins to update the drink weight to `$::de1(final_espresso_weight)` and `$::settings(running_weight)` During flow, the default implementation is track the weight estimate directly.
 
 ### Activate SAV
 


### PR DESCRIPTION
**Motivation**
Commit b619ebf5 extended the usage of **$::settings(drink_weight)** to store the weight of the last espresso shot **or the last hot water shot**. Previously that field was used only for espresso shots.

The problem is that `$::settings(drink_weight)` was also being used forshot metadata. End users could modify `$::settings(drink_weight)` after the shot, either in Insight ("My espresso" tab in the Godshots page) or using the DYE plugin. The field was also being stored in the SDB database, and in visualizer.coffee. 

After the change, if a user pours hot water after making a shot, the weight of the hot water is saved on `$::settings(drink_weight)`, overwritting the weight of the last espresso. If now the user tries to edit his last espresso shot, re-upload it to Visualizer, etc., he gets the wrong weight value in the shot file, in the SDB database, and/or in Visualizer.

`$::settings(drink_weight)` is also being used to show the weight of the last espresso shot (and not hot water) in the DSx home page, so the wrong value is shown if hot water has been poured after the espresso shot, as in this capture (the chart shows the espresso drink weight was around 36 g, but the value on the bottom shows 16.8 g instead, the weight of the hot water done after the shot), CC @Damian-AU : 
![image](https://user-images.githubusercontent.com/60866/121218891-77bbcf00-c883-11eb-8be5-403ab3f710da.png)

This bug was [reported by JoeD](https://decentforum.com/t/visualizer-upload-bug/1491/3).

**Changes**
A new settings variable is defined that contains the running weight during the shot of either espresso or hot water, so that `$::settings(drink_weight)` is now only used for the after-shot weight of espressos. The new variable is **$::settings(running_weight)**, and its value can be retrieved as a string using command `drink_weight_text` (note that this proc has not changed its name at the moment as it is used in several skins).

**$::settings(drink_weight)** recovers its original meaning and is set only when an espresso shot is finished.
