### PR TITLE
DUI: Fix -image option for dui::add::dbutton and relative paths in images resizing

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -3371,7 +3371,7 @@ namespace eval ::dui {
 				}
 			}
 			
-			if { [string is true $rescale] } {
+			if { [string is true $rescale] && [file pathtype $filename] in {relative volumerelative} } {
 				set src_filename ""
 				foreach dir [dui image dirs] {
 					set full_fn [file join $dir "[expr {int($::dui::_base_screen_width)}]x[expr {int($::dui::_base_screen_height)}]" $filename]
@@ -3384,12 +3384,12 @@ namespace eval ::dui {
 				if { $src_filename eq "" } {
 					msg -WARNING [namespace current] "image file '$filename' not found"
 					return ""
-				} else {
+				} else {					
+					set filename [file join $dir "${screen_size_width}x${screen_size_height}" $filename]
 					catch {
-						file mkdir [file join $dir "${screen_size_width}x${screen_size_height}"]
+						file mkdir [file dirname $filename]
 					}
 					
-					set filename  [file join $dir "${screen_size_width}x${screen_size_height}" [file tail $filename]]
 					msg -DEBUG [namespace current] "resizing image $src_filename to $filename"
 					dui say [translate "Resizing image"]
 					
@@ -6220,7 +6220,7 @@ namespace eval ::dui {
 			set i 0
 			set suffix ""
 			while { [info exists image$suffix] && [subst \$image$suffix] ne "" } {
-				dui add image $pages [subst \$xsymbol$suffix] [subst \$ysymbol$suffix] -text [subst \$image$suffix] \
+				dui add image $pages [subst \$ximage$suffix] [subst \$yimage$suffix] [subst \$image$suffix] \
 					-tags [subst \$image${suffix}_tags] -aspect_type "dbutton_image$suffix" \
 					-style $style {*}[subst \$image${suffix}_args]
 				set suffix [incr i]


### PR DESCRIPTION
This fixes a bug [reported](https://3.basecamp.com/3671212/buckets/7351439/messages/3803211859#__recording_3847087994) by @Damian-AU that the -image option in dui::add::dbutton was not working correctly.

While fixing this I found another bug, that relative image paths were not being preserved when the image is automatically resized to a new screen resolution if the image is in a subfolder of a <screen_size_width>x<screen_size_height> folder. This has been fixed and now the new resized image is created in the same relative subfolder of the new resolution.