### PR TITLE
Correct "list must have an even number of elements" in nightly 1.36.5.65

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -4499,7 +4499,7 @@ namespace eval ::dui {
 							$can itemconfigure $item -state disabled
 							if { $state eq "normal" } {
 								# Do NOT just show the items. We need to check we're still in the same page after the 400 ms
-								after 400 dui::item::show $page_to_show $item 1
+								after 400 dui::item::show $page_to_show $item
 							}
 						} else {
 							$can itemconfigure $item -state $state


### PR DESCRIPTION
Corrects a bug in DUI introduced by PR #171, that is constantly showing runtime error "list must have an even number of elements".