### PR TITLE
Increase tapping area of dcombobox dropdown. DUI pages adapt to theme

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -6075,8 +6075,8 @@ namespace eval ::dui {
 		# Invisible buttons can show their clickable area while debugging, by setting namespace variable debug_buttons=1.
 		#	In that case, the outline color is given by aspect 'button.debug_outline' (or black if undefined).
 		# Generates up to 3 canvas items/tags per page. Default one is named upon the provided -tags and corresponds to 
-		#	the invisible "clickable" area. If a visible button is generated, it its assigned tag "<tag>.button".
-		#	If a label is specified, it gets tag "<tag>.label". Returns the list of all added tags.
+		#	the invisible "clickable" area. If a visible button is generated, it its assigned tag "<tag>-btn".
+		#	If a label is specified, it gets tag "<tag>-lbl". Returns the canvas ID of the invisible clickable rectangle.
 		#
 		# Named options:  
 		#	If the first two arguments are integer numbers, they are interpreted as the absolute bottom-right coordinates
@@ -6086,7 +6086,9 @@ namespace eval ::dui {
 		#	-bheight to set the height of the button. If this is provided, y1 is ignored and height is added to y0 instead.
 		#		Normally bwidth and bheight are used when defining a button style in the theme aspects, so that buttons
 		#		using a given style always have the same size.
-		#	-shape any of 'rect', 'rounded' (Barney/MimojaCafe style) or 'outline' (DSx style)
+		#	-shape: empty string for an invisible rectangle, or any of 'rect', 'oval', 'rounded' (Barney/MimojaCafe style),
+		#		'outline' (rounded rectangle outline without a fill, DSx style), or 'rounded_outline' (rounded rectangle
+		#		outline with a fill color).
 		#	-style to apply the default aspects of the provided style
 		#	-command tcl code to be run when the button is clicked
 		#	-label, -label1, -label2... label text, in case a label is to be shown inside the button
@@ -6254,6 +6256,18 @@ namespace eval ::dui {
 					
 					set ids [dui::item::rounded_rectangle_outline $x $y $x1 $y1 $arc_offset $outline $disabledoutline \
 						$width $button_tags]
+				} elseif { $shape eq "round_outline" } {
+					set fill [dui::args::get_option -fill [dui aspect get dbutton fill -style $style]]
+					set disabledfill [dui::args::get_option -disabledfill [dui aspect get dbutton disabledfill -style $style]]
+					set radius [dui::args::get_option -radius [dui aspect get dbutton radius -style $style -default 40]]
+					set outline [dui::args::get_option -outline [dui aspect get dbutton outline -style $style]]
+					set disabledoutline [dui::args::get_option -disabledoutline [dui aspect get dbutton disabledoutline -style $style]]
+					set width [dui::args::get_option -width [dui aspect get dbutton width -style $style -default 3]]
+					
+					set ids [dui::item::rounded_rectangle $x $y $x1 $y1 $radius $fill $disabledfill $button_tags]
+					set outline_tags [list ${main_tag}-out {*}[lrange $tags 1 end]]
+					set ids [dui::item::rounded_rectangle_outline $x $y $x1 $y1 $radius $outline \
+						$disabledoutline $width $outline_tags]
 				} elseif { $shape eq "oval" } {
 					set ids [$can create oval $rx $ry $rx1 $ry1 -tags $button_tags -state hidden {*}$args]
 				} else {

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -5125,12 +5125,11 @@ namespace eval ::dui {
 		proc relocate_text_wrt { page tag wrt { pos w } { xoffset 0 } { yoffset 0 } { anchor {} } { move_too {} } } {
 			set can [dui canvas]
 			set page [lindex $page 0]
-set debug [expr {$wrt eq "roast_level"}]			
 			set tag [get $page [lindex $tag 0]]
 			set wrt [get $page [lindex $wrt 0]]
 			lassign [$can bbox $wrt] x0 y0 x1 y1 
 			lassign [$can bbox $tag] wx0 wy0 wx1 wy1
-if { $debug } { msg "WRT COORDS: ($x0 $y0 $x1 $y1)" }			
+			
 			set xoffset [dui platform rescale_x $xoffset]
 			set yoffset [dui platform rescale_y $yoffset]
 			
@@ -5194,10 +5193,8 @@ if { $debug } { msg "WRT COORDS: ($x0 $y0 $x1 $y1)" }
 			
 			if { $lcoords == 2 } {
 				$can coords $tag [list $newx $newy]
-if { $debug } { msg "RELOCATING '$tag' FROM ($wx0 $wy0) to ($newx $newy)" }				
 			} elseif { $lcoords == 4 } {
 				$can coords $tag [list $newx $newy [expr {$newx+($wx1-$wx0)}] [expr {$newy+($wy1-$wy0)}]]
-if { $debug } { msg "RELOCATING '$tag' FROM ($wx0 $wy0) to ($newx $newy [expr {$newx+($wx1-$wx0)}] [expr {$newy+($wy1-$wy0)}])" }
 			}
 			
 			if { $move_too ne "" } {
@@ -5210,12 +5207,10 @@ if { $debug } { msg "RELOCATING '$tag' FROM ($wx0 $wy0) to ($newx $newy [expr {$
 					
 					if { [llength $mtcoords] == 2 } {
 						$can coords $w [list [expr {$newx+$mtxoffset}] [expr {$newy+$mtyoffset}]]
-if { $debug } { msg "MOVING TOO '$w' FROM ([lindex $mtcoords 0] [lindex $mtcoords 1]) to ([expr {$newx+$mtxoffset}] [expr {$newy+$mtyoffset}])" }						
 					} elseif { [llength $mtcoords] == 4 } {
 						$can coords $w [list [expr {$newx+$mtxoffset}] [expr {$newy+$mtyoffset}] \
 							[expr {$newx+$mtxoffset+[lindex $mtcoords 2]-[lindex $mtcoords 0]}] \
 							[expr {$newy+$mtyoffset+[lindex $mtcoords 3]-[lindex $mtcoords 1]}]]
-if { $debug } { msg "MOVING TOO '$w' FROM ([lindex $mtcoords 0] [lindex $mtcoords 1]) to ([expr {$newx+$mtxoffset}] [expr {$newy+$mtyoffset}] [expr {$newx+$mtxoffset+[lindex $mtcoords 2]-[lindex $mtcoords 0]}] [expr {$newy+$mtyoffset+[lindex $mtcoords 3]-[lindex $mtcoords 1]}])" }						
 					}
 				}
 			}

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -3946,7 +3946,7 @@ namespace eval ::dui {
 	### PAGE SUB-ENSEMBLE ###
 	namespace eval page {
 		namespace export add current exists is_setup is_drawn is_visible list theme retheme delete get_namespace \
-			load show add_action actions items has_item add_items add_variable update_onscreen_variables	
+			load show add_action actions items has_item	update_onscreen_variables
 		namespace ensemble create
 		
 		# Metadata for every added page. Array keys have the form '<page_name>,<type>', where <type> can be:
@@ -4531,7 +4531,7 @@ namespace eval ::dui {
 			#set end [clock milliseconds]
 			#puts "elapsed: [expr {$end - $start}]"
 			
-			dui page update_onscreen_variables
+			dui::page::update_onscreen_variables
 			dui platform hide_android_keyboard
 			#msg [namespace current] "Switched to page: $page_to_show [stacktrace]"
 		}
@@ -5674,7 +5674,7 @@ namespace eval ::dui {
 				uplevel #0 $callback_cmd
 			}
 			
-			dui page update_onscreen_variables
+			dui::page::update_onscreen_variables
 			return
 		}
 
@@ -5764,7 +5764,7 @@ namespace eval ::dui {
 				uplevel #0 $callback_cmd
 			}
 			
-			dui page update_onscreen_variables
+			dui::page::update_onscreen_variables
 			return
 		}
 						
@@ -6046,7 +6046,7 @@ namespace eval ::dui {
 			set varcode [dui::args::get_option -textvariable "" 1]
 	
 			set id [dui add dtext $pages $x $y {*}$args]
-			dui page add_variable $pages $id $varcode
+			dui::page::add_variable $pages $id $varcode
 			return $id
 		}
 		

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -198,11 +198,11 @@ namespace eval ::dui {
 				#set fontw 2
 			}
 	
-			# HOW TO HANDLE THIS?
-			if {[file exists "skins/default/${screen_size_width}x${screen_size_height}"] != 1} {
-				set ::rescale_images_x_ratio [expr {$screen_size_height / $::dui::_base_screen_height}]
-				set ::rescale_images_y_ratio [expr {$screen_size_width / $::dui::_base_screen_width}]
-			}
+			# NOT NEEDED ANYMORE
+#			if {[file exists "skins/default/${screen_size_width}x${screen_size_height}"] != 1} {
+#				set ::rescale_images_x_ratio [expr {$screen_size_height / $::dui::_base_screen_height}]
+#				set ::rescale_images_y_ratio [expr {$screen_size_width / $::dui::_base_screen_width}]
+#			}
 	
 			set global_font_size 18
 			
@@ -282,10 +282,10 @@ namespace eval ::dui {
 			wm minsize . $screen_size_width $screen_size_height
 
 			# TBD WHAT TO DO WITH THIS 
-			if {[file exists "skins/default/${screen_size_width}x${screen_size_height}"] != 1} {
-				set ::rescale_images_x_ratio [expr {$screen_size_height / $::dui::_base_screen_height}]
-				set ::rescale_images_y_ratio [expr {$screen_size_width / $::dui::_base_screen_width}]
-			}
+#			if {[file exists "skins/default/${screen_size_width}x${screen_size_height}"] != 1} {
+#				set ::rescale_images_x_ratio [expr {$screen_size_height / $::dui::_base_screen_height}]
+#				set ::rescale_images_y_ratio [expr {$screen_size_width / $::dui::_base_screen_width}]
+#			}
 	
 			# EB: Is this installed by default on PC/Mac/Linux?? No need to sdltk add it?
 			set helvetica_font "notosansuiregular"
@@ -298,6 +298,7 @@ namespace eval ::dui {
 				#set fontm [expr {($fontm * 1.20)}]
 			} 
 		}
+		
 
 		set fontawesome_brands [dui::font::add_or_get_familyname "Font Awesome 5 Brands-Regular-400.otf"]
 		set fontawesome_pro [dui::font::add_or_get_familyname "Font Awesome 5 Pro-Regular-400.otf"]
@@ -4911,8 +4912,11 @@ namespace eval ::dui {
 		# For text, changes its fill color to the default or provided font or disabled color.
 		# For other widgets like rectangle "clickable" button areas, enables or disables them.
 		# Does nothing if the widget is hidden.
-		proc enable_or_disable { enabled page_or_ids_or_widgets {tags {}} } {
+		proc enable_or_disable { enabled page_or_ids_or_widgets {tags {}} args } {
 			set can [dui canvas]
+			array set opts $args
+			set do_current [string is true [dui::args::get_option -current 1]]
+			set do_initial [string is true [dui::args::get_option -initial 0]]
 			
 			if { [string is true $enabled] || $enabled eq "enable" } {
 				set state normal
@@ -4920,9 +4924,14 @@ namespace eval ::dui {
 				set state disabled
 			}
 						
-			foreach item [get $page_or_ids_or_widgets $tags] {
-				if { [$can itemcget $item -state] ne "hidden" } {
-					$can itemconfigure $item -state $state
+			foreach id [get $page_or_ids_or_widgets $tags] {
+				if { $do_current } {
+					if { [$can itemcget $id -state] ne "hidden" } {
+						$can itemconfigure $id -state $state
+					}
+				}
+				if { $do_initial } {
+					dui item config $id -initial_state $state
 				}
 			}
 		} 
@@ -4931,12 +4940,12 @@ namespace eval ::dui {
 		# For text, changes its fill color to the default or provided disabled color.
 		# For other widgets like rectangle "clickable" button areas, disables them.
 		# Does nothing if the widget is hidden. 
-		proc disable { page_or_ids_or_widgets {tags {}} } {
-			enable_or_disable 0 $page_or_ids_or_widgets $tags
+		proc disable { page_or_ids_or_widgets {tags {}} args } {
+			enable_or_disable 0 $page_or_ids_or_widgets $tags {*}$args
 		}
 		
-		proc enable { page_or_ids_or_widgets {tags {}} } {
-			enable_or_disable 1 $page_or_ids_or_widgets $tags
+		proc enable { page_or_ids_or_widgets {tags {}} args } {
+			enable_or_disable 1 $page_or_ids_or_widgets $tags {*}$args
 		}
 		
 		# "Smart" widgets shower or hider. 'show' can take any value equivalent to boolean (1, true, yes, etc.)

--- a/de1plus/gui.tcl
+++ b/de1plus/gui.tcl
@@ -149,67 +149,68 @@ proc photoscale_android {img sx {sy ""} } {
 }
 
 proc add_de1_page {names filename {skin ""} } {
-
-	set ::settings(preload_all_page_images) 0
-
-	if {$skin == ""} {
-		set skin $::settings(skin)
-	}
-
-	set pngfilename "[homedir]/skins/$skin/${::screen_size_width}x${::screen_size_height}/$filename"
-	set srcfilename "[homedir]/skins/$skin/2560x1600/$filename"
-
-	set make_new_image 0
-	if {$::screen_size_width == 1280 && $::screen_size_height == 800} {
-		# no redoing, as these are shipping with the app
-	} elseif {$::screen_size_width == 2560 && $::screen_size_height == 1600} {
-		# no redoing, as these are shipping with the app
-	} elseif {[file exists $pngfilename] != 1} {
-		set make_new_image 1
-		msg -DEBUG "Making new image because destination image does not exist: $pngfilename"
-	} elseif {[file mtime $srcfilename] > [file mtime $pngfilename]} {
-		# if the source image is newer than the target image, 
-		set make_new_image 1
-		msg -DEBUG "Making new image because date of src image is newer: $srcfilename"
-	}
-
-	if {$make_new_image == 1} {
-        borg toast [subst {[translate "Resizing image"]\n\n[file tail $filename]}]
-		borg spinner on
-    	catch {
-    		file mkdir "[homedir]/skins/$skin/${::screen_size_width}x${::screen_size_height}/"
-    	}
-
-
-        set rescale_images_x_ratio [expr {$::screen_size_height / 1600.0}]
-        set rescale_images_y_ratio [expr {$::screen_size_width / 2560.0}]
-
-		image create photo $names -file $srcfilename
-		photoscale $names $rescale_images_y_ratio $rescale_images_x_ratio
-		borg spinner off
-		$names write $pngfilename  -format {jpeg -quality 90}
-		image delete $names
-
-	} else {
-		if {$::settings(preload_all_page_images) == 1} {
-			set iname [image create photo $names -file $pngfilename]
-			msg -DEBUG "loading page: '$names' with image '$pngfilename' with tclname: '$iname'"
-			#image create photo $names 			$names -file $pngfilename
-		}
-	}
-
-	#.can create image {0 0} -anchor nw -image $names -tag [list pages $name] -state hidden 
-	foreach name $names {
-		.can create image {0 0} -anchor nw  -tag [list pages $name] -state hidden 
-		if {$::settings(preload_all_page_images) == 1} {
-			#.can itemconfigure $names -image $names 
-			.can itemconfigure $name -image $names
-		} else {
-			set ::delayed_image_load($name) $pngfilename
-		}
-	}
-
-	#set ::image_to_page($pngfilename) $names
+	dui page add $names -bg_img $filename
+	
+#	set ::settings(preload_all_page_images) 0
+#
+#	if {$skin == ""} {
+#		set skin $::settings(skin)
+#	}
+#
+#	set pngfilename "[homedir]/skins/$skin/${::screen_size_width}x${::screen_size_height}/$filename"
+#	set srcfilename "[homedir]/skins/$skin/2560x1600/$filename"
+#
+#	set make_new_image 0
+#	if {$::screen_size_width == 1280 && $::screen_size_height == 800} {
+#		# no redoing, as these are shipping with the app
+#	} elseif {$::screen_size_width == 2560 && $::screen_size_height == 1600} {
+#		# no redoing, as these are shipping with the app
+#	} elseif {[file exists $pngfilename] != 1} {
+#		set make_new_image 1
+#		msg -DEBUG "Making new image because destination image does not exist: $pngfilename"
+#	} elseif {[file mtime $srcfilename] > [file mtime $pngfilename]} {
+#		# if the source image is newer than the target image, 
+#		set make_new_image 1
+#		msg -DEBUG "Making new image because date of src image is newer: $srcfilename"
+#	}
+#
+#	if {$make_new_image == 1} {
+#        borg toast [subst {[translate "Resizing image"]\n\n[file tail $filename]}]
+#		borg spinner on
+#    	catch {
+#    		file mkdir "[homedir]/skins/$skin/${::screen_size_width}x${::screen_size_height}/"
+#    	}
+#
+#
+#        set rescale_images_x_ratio [expr {$::screen_size_height / 1600.0}]
+#        set rescale_images_y_ratio [expr {$::screen_size_width / 2560.0}]
+#
+#		image create photo $names -file $srcfilename
+#		photoscale $names $rescale_images_y_ratio $rescale_images_x_ratio
+#		borg spinner off
+#		$names write $pngfilename  -format {jpeg -quality 90}
+#		image delete $names
+#
+#	} else {
+#		if {$::settings(preload_all_page_images) == 1} {
+#			set iname [image create photo $names -file $pngfilename]
+#			msg -DEBUG "loading page: '$names' with image '$pngfilename' with tclname: '$iname'"
+#			#image create photo $names 			$names -file $pngfilename
+#		}
+#	}
+#
+#	#.can create image {0 0} -anchor nw -image $names -tag [list pages $name] -state hidden 
+#	foreach name $names {
+#		.can create image {0 0} -anchor nw  -tag [list pages $name] -state hidden 
+#		if {$::settings(preload_all_page_images) == 1} {
+#			#.can itemconfigure $names -image $names 
+#			.can itemconfigure $name -image $names
+#		} else {
+#			set ::delayed_image_load($name) $pngfilename
+#		}
+#	}
+#
+#	#set ::image_to_page($pngfilename) $names
 }	
 
 proc set_de1_screen_saver_directory {{dirname {}}} {
@@ -699,7 +700,7 @@ proc platform_button_unpress {} {
 
 
 proc add_variable_item_to_context {context label_name varcmd} {
-	msg -WARN "add_variable_item_to_context is OBSOLETE, please use DUI instead"
+	msg -WARNING "add_variable_item_to_context is DEPRECATED, please use 'dui page add_variable' instead"
 	# This may or may not work as dui::page::add_variable takes canvas IDs instead of labels.
 	dui::page::add_variable $context $label_name $varcmd
 	

--- a/de1plus/utils.tcl
+++ b/de1plus/utils.tcl
@@ -46,6 +46,12 @@ proc setup_environment {} {
 		set settings(screen_size_height) $::screen_size_height
 		save_settings
 #	}
+	# Enrique: This shouldn't be necessary anymore but still the $::rescale_*_ratio vars are used in a couple of procs
+	if { ![file exists "skins/default/${::screen_size_width}x${::screen_size_height}"] } {
+		set ::rescale_images_x_ratio [expr {$::screen_size_height / $::dui::_base_screen_height}]
+		set ::rescale_images_y_ratio [expr {$::screen_size_width / $::dui::_base_screen_width}]
+	}
+
 
 	# Re-store what are now DUI namespace variables into the original global variables to ensure backwards-compatibility
 	# with existing code, until all code is migrated.
@@ -1042,19 +1048,20 @@ proc get_set_tablet_brightness { {setting ""} } {
 }
 
 
-proc settings_directory_graphics {} {
-    
-    global screen_size_width
-    global screen_size_height
-
-    set settingsdir "[homedir]/skins"
-    set dir "$settingsdir/$::settings(skin)/${screen_size_width}x${screen_size_height}"
-    
-    if {[info exists ::rescale_images_x_ratio] == 1} {
-        set dir "$settingsdir/$::settings(skin)/2560x1600"
-    }
-    return $dir
-}
+# Enrique: Not used anywhere in the code as of 25/06/2021, image directories now managed by DUI, so commenting 
+#proc settings_directory_graphics {} {
+#    
+#    global screen_size_width
+#    global screen_size_height
+#
+#    set settingsdir "[homedir]/skins"
+#    set dir "$settingsdir/$::settings(skin)/${screen_size_width}x${screen_size_height}"
+#    
+#    if {[info exists ::rescale_images_x_ratio] == 1} {
+#        set dir "$settingsdir/$::settings(skin)/2560x1600"
+#    }
+#    return $dir
+#}
 
 proc skin_directory_graphics {} {
     global screen_size_width

--- a/documentation/decent_user_interface.md
+++ b/documentation/decent_user_interface.md
@@ -14,6 +14,130 @@
   - [Pages](#pages)
   - [Visual items (GUI elements)](#items)
 
+
+<a name="api_index"></a>
+
+## API Index
+
+- `dui`
+  - dui init
+  - dui canvas
+  - [dui config](#dui_config)
+  - [dui cget](#dui_cget)
+  - [dui say](#dui_say)
+  - _Non exported:_  dui::setup_ui
+- `dui platform`
+  - dui platform hide_android_keyboard
+  - dui platform button_press
+  - dui platform button_long_press
+  - dui platform finger_down
+  - dui platform button_unpress
+  - dui platform xscale_factor
+  - dui platform yscale_factor
+  - dui platform rescale_x
+  - dui platform rescale_y
+  - dui platform translate_coordinates_finger_down_x
+  - dui platform translate_coordinates_finger_down_y
+  - dui platform is_fast_double_tap
+- `dui theme`
+  - [dui theme add](#dui_theme_add)
+  - [dui theme set](#dui_theme_set)
+  - [dui theme get](#dui_theme_get)
+  - [dui theme exists](#dui_theme_exists)
+  - [dui theme list](#dui_theme_list)
+- `dui aspect`
+  - [dui aspect set](#dui_aspect_set)
+  - [dui aspect get](#dui_aspect_get)
+  - [dui aspect exists](#dui_aspect_exists)
+  - [dui aspect list](#dui_aspect_list)
+- `dui font`
+  - [dui font add_dirs](#dui_font_add_dirs)
+  - [dui font dirs](#dui_font_dirs)
+  - [dui font load](#dui_font_load)
+  - [dui font get](#dui_font_get)
+  - [dui font list](#dui_font_list)
+  - dui font width
+  - _Non exported:_  dui::font::add_or_get_familyname, dui::font::key
+- `dui symbol`
+  - [dui symbol_set](#dui_symbol_set)
+  - [dui symbol get](#dui_symbol_get)
+  - [dui symbol exists](#dui_symbol_exists)
+  - [dui symbol list](#dui_symbol_list)
+- `dui image`
+  - [dui image add_dirs](#dui_image_add_dirs)
+  - [dui image dirs](#dui_image_dirs)
+  - [dui image find](#dui_image_find)
+  - _Non exported:_  dui::image::photoscale, dui::image::find, dui::image::load, dui::image::is_loaded, dui::image::get, dui::image::set_delayed, dui::image::exists_delayed, dui::image::load_delayed, dui::image::rm_delayed.
+- `dui sound`
+  - [dui sound set](#dui_sound_set)
+  - [dui sound get](#dui_sound_get)
+  - [dui sound exists](#dui_sound_exists)
+  - [dui sound make](#dui_sound_make)
+  - [dui sound list](#dui_sound_list)  
+- `dui page`
+  - [dui page add](#dui_page_add)
+  - [dui page theme](#dui_page_theme)
+  - [dui page exists](#dui_page_exists)
+  - [dui page is_setup](#dui_page_is_setup)
+  - [dui page is_drawn](#dui_page_is_drawn)
+  - [dui page is_visible](#dui_page_is_visible)
+  - [dui page current](#dui_page_current)
+  - [dui page list](#dui_page_list)
+  - [dui page get_namespace](#dui_page_get_namespace)
+  - [dui page load](#dui_page_load)
+  - [dui page show](#dui_page_show)
+  - [dui page add_action](#dui_page_add_action)
+  - [dui page actions](#dui_page_actions)
+  - [dui page delete](#dui_page_delete)
+  - [dui page retheme](#dui_page_retheme)
+  - [dui page items](#dui_page_items)
+  - [dui page has_item](#dui_page_has_item)
+  - dui page update_onscreen_variables
+  - _Non exported:_  dui::page::setup, dui::page::add_items, dui::page::add_variable.
+- `dui item`
+  - [dui item add](#dui_item_add)
+  - [dui item get](#dui_item_get)
+  - [dui item get_widget](#dui_item_get_widget)
+  - [dui item pages](#dui_item_pages)
+  - [dui item config](#dui_item_config)
+  - [dui item cget](#dui_item_cget)
+  - [dui item enable](#dui_item_enable)
+  - [dui item disable](#dui_item_disable)
+  - [dui item enable_or_disable](#dui_item_enable_or_disable)
+  - [dui item show](#dui_item_show)
+  - [dui item hide](#dui_item_hide)
+  - [dui item show_or_hide](#dui_item_show_or_hide)
+  - [dui item moveto](#dui_item_moveto)
+  - [dui item listbox_get_selection](#dui_item_listbox_get_selection)
+  - [dui item listbox_set_selection](#dui_item_listbox_set_selection)
+  - _Non exported:_  dui::item::relocate_text_wrt, dui::item::relocate_dropdown_arrow, dui::item::ensure_size, dui::item::set_yscrollbar_dim, dui::item::scale_scroll, dui::item::scrolled_widget_moveto, dui::item::rounded_rectangle, dui::item::rounded_rectangle_outline, dui::item::scale_moveto, dui::item::drater_draw, dui::item::drater_clicker, dui::item::horizontal_clicker, dui::item::vertical_clicker, dui::item::anchor_inside_box, dui::item::anchor_coords.
+- `dui add`
+  - [dui add theme](#dui_add_theme)
+  - [dui add aspect](#dui_add_aspect)
+  - [dui add symbol](#dui_add_symbol)
+  - [dui add page](#dui_add_page)
+  - [dui add font](#dui_add_font)
+  - [dui add font_dirs](#dui_add_font_dirs)
+  - [dui add image_dirs](#dui_add_image_dirs)
+  - [dui add canvas_item](#dui_add_canvas_item)
+  - [dui add widget](#dui_add_widget)
+  - [dui add dtext](#dui_add_dtext)
+  - [dui add variable](#dui_add_variable)
+  - [dui add image](#dui_add_image)
+  - [dui add dbutton](#dui_add_dbutton)
+  - [dui add dclicker](#dui_add_dclicker)
+  - [dui add entry](#dui_add_entry)
+  - [dui add multiline_entry](#dui_add_multiline_entry)
+  - [dui add text](#dui_add_text)
+  - [dui add listbox](#dui_add_listbox)
+  - [dui add dcheckbox](#dui_add_dcheckbox)
+  - [dui add scale](#dui_add_scale)
+  - [dui add drater](#dui_add_drater)
+  - [dui add graph](#dui_add_graph)
+- `dui args`
+  - _Non exported:_  dui::args::add_option_if_not_exists, dui::args::remove_options, dui::args::has_option, dui::args::get_option, dui::args::extract_prefixed, dui::args::process_tags_and_var, dui::args::process_aspects, dui::args::process_font, dui::args::process_label.
+
+
 <a name="objective"></a>
 
 ## Objective
@@ -949,6 +1073,13 @@ Items are selected in the same way as in **dui item get**. Add a "*" suffix to a
 >>If **-initial** is  _true_ , permanently modifies the initial show/hide state of the item, that is, whether is is shown or hidden whenever its page is shown. Default value is  _false_ .
 
 
+<a name="dui_item_moveto"></a>
+
+**dui item moveto**  _page_or_id_or_widget tag x y_
+
+>Moves items to a new screen location.  _x_  and  _y_  give the new top-left coordinates. If  _tag_  selects all items in a compound (ends with a "*" character), all individual items of the compound will be moved, preserving their relative positions (use this to move, for example, dbuttons).
+
+
 <a name="dui_item_listbox_get_selection"></a>
 
 **dui item listbox_get_selection**  _page_or_id_or_widget ?tag values?_
@@ -961,13 +1092,6 @@ Items are selected in the same way as in **dui item get**. Add a "*" suffix to a
 **dui item listbox_set_selection**  _page_or_id_or_widget tag selected ?values reset_current?_
 
 >Selects the items matching the  _selected_  string in the specified listbox widget. If a  _values_  list is provided,  _selected_  is matched against  _values_  instead of the list values. If  _reset_current_  is 1 (or any other value that is coerced to a boolean  _true_ ), the current selection is reset first (this is only relevant with listboxes that accept multiple selections).
-
-
-<a name="dui_item_moveto"></a>
-
-**dui item moveto**  _page_or_id_or_widget tag x y_
-
->Moves items to a new screen location.  _x_  and  _y_  give the new top-left coordinates. If  _tag_  selects all items in a compound (ends with a "*" character), all individual items of the compound will be moved, preserving their relative positions (use this to move, for example, dbuttons).
 
 
 <a name="dui_add"></a>
@@ -1453,6 +1577,51 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 > >Use this syntax to pass additional options to the yscrollbar scale creation command.
 
 
+<a name="dui_add_text"></a>
+
+**dui add text**  _pages x y ?-option value ...?_
+
+>Create a Tk text widget and add it to the requested  _pages_  at coordinates  _{x, y}_ . 
+
+>Return the pathname of the Text widget. The command also adds (if applicable) the following named tags to the canvas, and the same keys in the widgets page namespace array: 
+
+> >&lt;main_tag&gt;: the Text widget.
+
+> >&lt;main_tag&gt;-lbl: (optional) the canvas ID of the label text.
+
+> >&lt;main_tag&gt;-ysb: (optional) the Tk scale widget used as vertical scrollbar.
+
+>Non-DUI options are passed-through to the Tk [text](https://www.tcl.tk/man/tcl8.6/TkCmd/text.htm) command.
+
+>**-label**  _text_
+
+>**-labelvariable**  _tcl_code_
+
+> >If **-label** or **-labelvariable** are used, adds a fixed or dynamic text label, respectively, associated to the text widget.
+
+>**-label_pos**  _{x y}_
+
+>**-label_pos**  _{anchor ?x_offset? ?y_offset?}_
+
+> >A list that determines the location of the label. If a pair of numeric coordinates are provided, they are interpreted as direct coordinates in the screen. If the first list item is not a number, it is interpreted as an anchor point relative to the edges of the listbox widget, and the label will be moved to the target position when the page is shown. 
+
+> >Valid anchor values are "n", "nw", "ne", "s", "sw", "se", "w", "wn", "ws", "e", "en", "es". To get the label placed exactly as you want you normally also have to play with **-label_anchor** and **-label_justify**.
+
+> >The anchor value can optionally be followed by an  _x_offset_  and a  _y_offset_ , which will move the position by those fixed offsets after the anchor point is determined.
+
+>**-label_***option*** **  _value_
+
+> >Use this syntax to pass additional options to the label creation command. They will be passed through to either **dui add dtext** if **-label** was used, or to **dui add variable** if **-labelvariable** was used.
+
+>**-yscrollbar**  _true_or_false_
+
+> >If  _true_ , a vertical scrollbar is added to the right side of the text widget. The scrollbar is actually a Tk scale widget, not a Tk scrollbar widget. 
+
+>**-yscrollbar_***option*** **  _value_
+
+> >Use this syntax to pass additional options to the yscrollbar scale creation command.
+
+
 <a name="dui_add_listbox"></a>
 
 **dui add listbox**  _pages x y ?-option value ...?_
@@ -1740,48 +1909,3 @@ $widget element create ...
 $widget element create line_history_left_chart -xdata <xdata> -ydata <ydata> \
     {*}[dui aspect list -type graph_line -style hv_line -as_options yes]
 ```
-
-
-<a name="dui_add_text"></a>
-
-**dui add text**  _pages x y ?-option value ...?_
-
->Create a Tk text widget and add it to the requested  _pages_  at coordinates  _{x, y}_ . 
-
->Return the pathname of the Text widget. The command also adds (if applicable) the following named tags to the canvas, and the same keys in the widgets page namespace array: 
-
-> >&lt;main_tag&gt;: the Text widget.
-
-> >&lt;main_tag&gt;-lbl: (optional) the canvas ID of the label text.
-
-> >&lt;main_tag&gt;-ysb: (optional) the Tk scale widget used as vertical scrollbar.
-
->Non-DUI options are passed-through to the Tk [text](https://www.tcl.tk/man/tcl8.6/TkCmd/text.htm) command.
-
->**-label**  _text_
-
->**-labelvariable**  _tcl_code_
-
-> >If **-label** or **-labelvariable** are used, adds a fixed or dynamic text label, respectively, associated to the text widget.
-
->**-label_pos**  _{x y}_
-
->**-label_pos**  _{anchor ?x_offset? ?y_offset?}_
-
-> >A list that determines the location of the label. If a pair of numeric coordinates are provided, they are interpreted as direct coordinates in the screen. If the first list item is not a number, it is interpreted as an anchor point relative to the edges of the listbox widget, and the label will be moved to the target position when the page is shown. 
-
-> >Valid anchor values are "n", "nw", "ne", "s", "sw", "se", "w", "wn", "ws", "e", "en", "es". To get the label placed exactly as you want you normally also have to play with **-label_anchor** and **-label_justify**.
-
-> >The anchor value can optionally be followed by an  _x_offset_  and a  _y_offset_ , which will move the position by those fixed offsets after the anchor point is determined.
-
->**-label_***option*** **  _value_
-
-> >Use this syntax to pass additional options to the label creation command. They will be passed through to either **dui add dtext** if **-label** was used, or to **dui add variable** if **-labelvariable** was used.
-
->**-yscrollbar**  _true_or_false_
-
-> >If  _true_ , a vertical scrollbar is added to the right side of the text widget. The scrollbar is actually a Tk scale widget, not a Tk scrollbar widget. 
-
->**-yscrollbar_***option*** **  _value_
-
-> >Use this syntax to pass additional options to the yscrollbar scale creation command.

--- a/documentation/decent_user_interface.md
+++ b/documentation/decent_user_interface.md
@@ -903,15 +903,24 @@ command if it is a canvas item.
 
 <a name="dui_item_enable_or_disable"></a>
 
-**dui item enable**  _page_or_ids_or_widgets ?tags?_
+**dui item enable**  _page_or_ids_or_widgets ?tags? ?-option value ...?_
 
-**dui item disable**  _page_or_ids_or_widgets ?tags?_
+**dui item disable**  _page_or_ids_or_widgets ?tags? ?-option value ...?_
 
-**dui item enable_or_disable**  _enabled page_or_ids_or_widgets ?tags?_
+**dui item enable_or_disable**  _enabled page_or_ids_or_widgets ?tags? ?-option value ...?_
 
 >Enable or disable the specified canvas items or widgets. 
 Items are selected in the same way as in **dui item get**. Add a "*" suffix to a main tag to enable or disable all the items in a widget compound at once.
 _enabled_ can be any value that is coerced to a boolean (1/0, true/false, etc.)
+
+>**-current**  _boolean_
+
+>>If **-current** is  _true_ , enables or disables the item immediately. Default value is  _true_ .
+
+>**-initial**  _boolean_
+
+>>If **-initial** is  _true_ , permanently modifies the initial enabled/disabled state of the item, that is, whether is is shown enabled (normal) or disabled whenever its page is shown. Default value is  _false_ .
+
 
 
 <a name="dui_item_show_or_hide"></a>

--- a/documentation/decent_user_interface.md
+++ b/documentation/decent_user_interface.md
@@ -652,10 +652,9 @@ variable **create_page_namespaces**.
 
 <a name="dui_page_theme"></a>
 
-**dui page theme**
+**dui page theme**  _default_ 
 
->Returns the name of the theme used when creating the page.
-
+>Returns the name of the theme used when creating the page. If the page has no namespace (and thus has no theme assigned), returns  _default_ , which, if not specified, is an empty string.
 
 <a name="dui_page_exists"></a>
 

--- a/documentation/decent_user_interface.md
+++ b/documentation/decent_user_interface.md
@@ -169,7 +169,7 @@ toolkit basics), and the [TkDocs online tutorial](https://tkdocs.com/).
 ## Revision History
 
 * 2021-04-10 – Initial writing by [Enrique Bengoechea](https://github.com/ebengoechea)
-* 2021-04-10 - 2021-05-14 - Rewrite while the API evolves through nightly & beta, by [Enrique Bengoechea](https://github.com/ebengoechea)
+* 2021-04-11 - 2021-06-27 - Rewrite while the API evolves through nightly & beta, by [Enrique Bengoechea](https://github.com/ebengoechea)
 
 <a name="history"></a>
 
@@ -1295,7 +1295,9 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 
 > >&lt;main_tag&gt;: the invisible "clickable" rectangle;
 
-> >&lt;main_tag&gt;-btn: the background button shape, which may itself be composed of several canvas items such as lines, rectangles and ovals;
+> >&lt;main_tag&gt;-btn: the background button shape, which may itself be composed of several canvas items such as lines, rectangles and ovals; For `-shape round_outline`, this is the background rounded rectangle.
+
+> >&lt;main_tag&gt;-out: the round button outline shape when `-shape round_outline` is used. It is itself composed of several canvas lines and arcs.
 
 > >&lt;main_tag&gt;-lbl, &lt;main_tag&gt;-lbl1, etc.: (optional) label text;
 
@@ -1327,10 +1329,11 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 
 > >-**round**: A rounded-corners filled rectangle. This type of button cannot have a border (outline). It is the type of buttons used in the Metric and MimojaCafe skins. It accepts as formatting options **-fill** (button fill color), **-disabledfill** (button fill color when disabled) and **-radius** (determines how "round" the rectangle corners are).
 
-> >-**outline**: A rounded-corners rectangle with a visible outline border. In this case, the fill color is that of the background, and cannot be modified. This is the type of button used in the DSx skin. It accepts as formatting options **-outline** (color of the outline), **-disabledoutline** (color of the outline when the button is disabled), **-arc_offset** (determines how "round" the rectangle corners are) and **-width** (line width of the outline border).
+> >-**outline**: A rounded-corners rectangle with a visible outline border. In this case, the fill color is that of the background, and cannot be modified. This is the type of button used in the DSx skin. It accepts as formatting options **-outline** (color of the outline), **-disabledoutline** (color of the outline when the button is disabled), **-arc_offset** (determines how "round" the rectangle corners are) and **-width** (line width of the outline border). When using DUI styles it may sometimes be necessary to explicitly set **-fill {}** so it's not inherited from dbutton defaults.
+
+> >-**round_outline**: A rounded-corners rectangle with a visible outline border which, unlike **outline**, can be filled with a color different from the background. This is actually built overlapping a "round" dbutton and an "outline" dbutton. It accepts as formatting options **-fill** (button fill color), **-disabledfill** (button fill color when disabled), **-outline** (color of the outline), **-disabledoutline** (color of the outline when the button is disabled), **-radius** (determines how "round" the rectangle corners are) and **-width** (line width of the outline border).
 
 >**-command**  _tcl_code_
-
 > >Callback Tcl code to run when the button is clicked. When the page has a namesapce, if a plain name is used (only letters, numbers and underscores) and the namespace has a command with that name, it is used. If not specified and the page namespace has a command with the same number as the main tag, it is used.
 
 > >In addition to the standard substitutions, DUI adds the following:


### PR DESCRIPTION
This brings 2 main updates to DUI:

1. The "clickable" area of the dropdown arrow of dcomboboxes was too small and often several touches were needed. It has been modified to be a dbutton with a bigger clickable area. This change needs matching updates in both DYE & MimojaCafe.

2. DUI auxiliar pages "dui_number_editor" and "dui_item_selector" now can be rethemed on the fly by passing a named argument -theme to the "dui page load" command. This is used to adapt its aspect to the page that opens them.

Other minor changes:

- dui::page::theme gets a new argument 'default'.
- dui::page::retheme now validates new_theme and logs invalid themes.
- Styles of buttons in dui_number_editor are now moved to the global theme.
- dui::item::relocate_text_wrt now can work with items different that text