### PR TITLE
Re-export dui::page::add_items

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -3946,7 +3946,7 @@ namespace eval ::dui {
 	### PAGE SUB-ENSEMBLE ###
 	namespace eval page {
 		namespace export add current exists is_setup is_drawn is_visible list theme retheme delete get_namespace \
-			load show add_action actions items has_item	update_onscreen_variables
+			load show add_action actions items has_item	update_onscreen_variables add_items
 		namespace ensemble create
 		
 		# Metadata for every added page. Array keys have the form '<page_name>,<type>', where <type> can be:


### PR DESCRIPTION
An error introduced by PR #174 was being raised as soon as the app was started on non-Insight skins.

dui::page::add_items had wrongly stopped being exported, now exported again.
