### PR TITLE
Add DUI default skin image folder after the current skin image folder

### DIFF
--- a/de1plus/utils.tcl
+++ b/de1plus/utils.tcl
@@ -17,8 +17,7 @@ proc setup_environment {} {
 		}
 	}
 	dui config language [language]
-	dui font add_dirs "[homedir]/fonts/"
-	dui image add_dirs "[homedir]/skins/default/"
+	dui font add_dirs "[homedir]/fonts/"	
 	dui config preload_images $::settings(preload_all_page_images)
 	dui sound set button_in "[homedir]/sounds/KeypressStandard_120.ogg" \
 		button_out "[homedir]/sounds/KeypressDelete_120.ogg" \
@@ -26,6 +25,9 @@ proc setup_environment {} {
 	
 	dui init $settings(screen_size_width) $settings(screen_size_height) $settings(orientation)
 	
+	# Do this after dui init, so if the same image is on the current skin and in default, the one in the skin directory takes precedence
+	dui image add_dirs "[homedir]/skins/default/"
+
 	source "bluetooth.tcl"
 	
 	# Configure actions on specific pages (this was previously hardcoded on page_display_change, and should be moved 


### PR DESCRIPTION
"Artistic" skins like 1960's were showing the default skind background page images instead of their own images, as [reported](https://github.com/decentespresso/de1app/commit/8759bbff46cfb3ff93e41428d23896153f446352#commitcomment-52736923) by @decentjohn. 

The reason was that if the same image file was found by DUI in both the current skin and the default skin, the default one took precedence because the default folder was first in the image search path list. So now the default image folder is added to the search path list _after_ the skin images folder.