### PR TITLE
Incr 1px on ends of lines&arcs in dui::item::rounded_rectangle_outline

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -5400,22 +5400,27 @@ namespace eval ::dui {
 			set x1 [dui platform rescale_x $x1] 
 			set y1 [dui platform rescale_y $y1]
 		
-			lappend ids [$can create arc [expr $x0] [expr $y0+$arc_offset] [expr $x0+$arc_offset] [expr $y0] -style arc -outline $colour \
-				-width [expr $width-1] -tags $tags -start 90 -disabledoutline $disabled -state "hidden"]
-			lappend ids [$can create arc [expr $x0] [expr $y1-$arc_offset] [expr $x0+$arc_offset] [expr $y1] -style arc -outline $colour \
-				-width [expr $width-1] -tags $tags -start 180 -disabledoutline $disabled -state "hidden"]
-			lappend ids [$can create arc [expr $x1-$arc_offset] [expr $y0] [expr $x1] [expr $y0+$arc_offset] -style arc -outline $colour \
-				-width [expr $width-1] -tags $tags -start 0 -disabledoutline $disabled -state "hidden"]
-			lappend ids [$can create arc [expr $x1-$arc_offset] [expr $y1] [expr $x1] [expr $y1-$arc_offset] -style arc -outline $colour \
-				-width [expr $width-1] -tags $tags -start -90 -disabledoutline $disabled -state "hidden"]
+			if { $width > 1 } {
+				set arc_width [expr {$width-1}]
+			} else {
+				set arc_width $width
+			}
+			lappend ids [$can create arc [expr $x0] [expr $y0+$arc_offset+1] [expr $x0+$arc_offset+1] [expr $y0] -style arc -outline $colour \
+				-width $arc_width -tags $tags -start 90 -disabledoutline $disabled -state "hidden"]
+			lappend ids [$can create arc [expr $x0] [expr $y1-$arc_offset-1] [expr $x0+$arc_offset+1] [expr $y1] -style arc -outline $colour \
+				-width $arc_width -tags $tags -start 180 -disabledoutline $disabled -state "hidden"]
+			lappend ids [$can create arc [expr $x1-$arc_offset-1] [expr $y0] [expr $x1] [expr $y0+$arc_offset+1] -style arc -outline $colour \
+				-width $arc_width -tags $tags -start 0 -disabledoutline $disabled -state "hidden"]
+			lappend ids [$can create arc [expr $x1-$arc_offset-1] [expr $y1] [expr $x1] [expr $y1-$arc_offset+1] -style arc -outline $colour \
+				-width $arc_width -tags $tags -start -90 -disabledoutline $disabled -state "hidden"]
 			
-			lappend ids [$can create line [expr $x0+$arc_offset/2] [expr $y0] [expr $x1-$arc_offset/2] [expr $y0] -fill $colour \
+			lappend ids [$can create line [expr $x0+$arc_offset/2-1] [expr $y0] [expr $x1-$arc_offset/2+1] [expr $y0] -fill $colour \
 				-width $width -tags $tags -disabledfill $disabled -state "hidden"]
-			lappend ids[$can create line [expr $x1] [expr $y0+$arc_offset/2] [expr $x1] [expr $y1-$arc_offset/2] -fill $colour \
+			lappend ids[$can create line [expr $x1] [expr $y0+$arc_offset/2-1] [expr $x1] [expr $y1-$arc_offset/2+1] -fill $colour \
 				-width $width -tags $tags -disabledfill $disabled -state "hidden"]
-			lappend ids[$can create line [expr $x0+$arc_offset/2] [expr $y1] [expr $x1-$arc_offset/2] [expr $y1] -fill $colour \
+			lappend ids[$can create line [expr $x0+$arc_offset/2-1] [expr $y1] [expr $x1-$arc_offset/2+1] [expr $y1] -fill $colour \
 				-width $width -tags $tags -disabledfill $disabled -state "hidden"]
-			lappend ids[$can create line [expr $x0] [expr $y0+$arc_offset/2] [expr $x0] [expr $y1-$arc_offset/2] -fill $colour \
+			lappend ids[$can create line [expr $x0] [expr $y0+$arc_offset/2-1] [expr $x0] [expr $y1-$arc_offset/2+1] -fill $colour \
 				-width $width -tags $tags -disabledfill $disabled -state "hidden"]
 			return $ids
 		}

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -317,10 +317,21 @@ namespace eval ::dui {
 
 		# Try to locate image folders automatically, in case they're not declared explicitly by the skin
 		set skin_img_dir [file normalize "${skin_dir}/${screen_size_width}x${screen_size_height}/"]
-		if { [file exists $skin_img_dir] && $skin_dir ni [dui item image_dirs] } {
-			dui image add_dirs $skin_dir
+		if { $skin_dir ni [dui item image_dirs] } {
+			if { [file exists $skin_img_dir] } {
+				dui image add_dirs $skin_dir
+			} elseif { [file exists "${skin_dir}/[expr {int($::dui::_base_screen_width)}]x[expr {int($::dui::_base_screen_height)}]/"] } {
+				try {
+					file mkdir $skin_img_dir
+					dui image add_dirs $skin_dir
+				} on error err {
+					msg -ERROR [namespace current] init: "can't create or folder '$skin_img_dir': $err"
+				}
+			} else {
+				msg -WARNING [namespace current] init: "skin default image directory '$skin_img_dir' not found, was not added"
+			}
 		}
-	
+		
 		# log dui settings for eventual debugging
 		msg -INFO "Platform data: tcl_platform=$::tcl_platform(platform), android=$android, undroid=$undroid, some_droid=$::some_droid"
 		msg -INFO "Screen data: width=$screen_size_width, height=$screen_size_height"


### PR DESCRIPTION
According to [this message](https://3.basecamp.com/3671212/buckets/7351439/messages/3803211859#__recording_3904677232) from @decentjohn, the lines and arcs in rounded rectangle outlines could be one pixel off (probably not showing on standard P80x tablet due to resolution & dithering). So one pixel has been added to the endings of the 4 lines and 4 arcs that compose the button outline.