### PR TITLE
Make DUI dscales work on tablets

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -5504,7 +5504,7 @@ namespace eval ::dui {
 			#	to a slider_coord value.
 			if { $slider_coord eq "" && $varname ne "" } {
 				if { [info exists $varname] } {
-					set varvalue [number_in_range [subst \$$varname] 0 $from $to $resolution $n_decimals]  
+					set varvalue [number_in_range [subst \$$varname] 0 $from $to $resolution $n_decimals]
 				} else {
 					set varvalue [number_in_range $from 0 $from $to $resolution $n_decimals]
 					set $varname $varvalue
@@ -5525,9 +5525,9 @@ namespace eval ::dui {
                     } elseif { $varvalue >= $to } {
                         switch $orient h {set slider_coord [expr {$bx1-$swidth}]} v {set slider_coord $by0 }
                     } elseif { $orient eq "h" } {
-                        set slider_coord [expr {$bx0+($bx1-$bx0-$swidth)*$varvalue/($to-$from)}]
+                        set slider_coord [expr {round($bx0+($bx1-$bx0-$swidth)*double($varvalue-$from)/double($to-$from))}]
                     } else {
-                        set slider_coord [expr {($by1-$sheight)+($by1-$by0-$sheight)*$varvalue/($from-$to)}]
+                        set slider_coord [expr {round(($by1-$sheight)+($by1-$by0-$sheight)*double($varvalue-$from)/double($from-$to))}]
                     }
 				} else {
 					return
@@ -5539,12 +5539,12 @@ namespace eval ::dui {
 				# Horizontal
                 #if { ($slider_coord-$swidth/2) <= $bx0 } 
 				if { ($slider_coord-$offset) <= $bx0 } {
-					$can coords $front $bx0 $by0 [expr {$bx0+$swidth/2}] $by1
+					$can coords $front $bx0 $by0 [expr {$bx0+$swidth/2.0}] $by1
 					$can coords $slider $bx0 $sy0 [expr {$bx0+$swidth}] $sy1
 					if { $varvalue eq "" } { set $varname $from }
                 #elseif { $slider_coord >= ($bx1-$swidth/2) }
 				} elseif { $slider_coord >= ($bx1-$swidth+$offset) } {
-					$can coords $front $bx0 $by0 [expr {$bx1-$swidth/2}] $by1
+					$can coords $front $bx0 $by0 [expr {$bx1-$swidth/2.0}] $by1
 					$can coords $slider [expr {$bx1-$swidth}] $sy0 $bx1 $sy1
 					if { $varvalue eq "" } { set $varname $to }
 				} else {
@@ -5553,7 +5553,7 @@ namespace eval ::dui {
                     $can move $slider [expr {$slider_coord-$sx0-$offset}] 0
 					if { $varvalue eq "" } {
 						#set newcoord [expr {$from+($to-$from)*(($slider_coord-$swidth/2-$bx0)/($bx1-$swidth-$bx0))}]
-                        set newcoord [expr {$from+($to-$from)*(($slider_coord-$offset-$bx0)/($bx1-$swidth-$bx0))}]
+                        set newcoord [expr {round($from+($to-$from)*(double($slider_coord-$offset-$bx0)/double($bx1-$swidth-$bx0)))}]
                         set $varname [number_in_range $newcoord {} $from $to $resolution $n_decimals]
 					}
 				} 
@@ -5561,21 +5561,21 @@ namespace eval ::dui {
 				# Vertical
                 #if { ($slider_coord-$sheight/2) <= $by0 } 
 				if { ($slider_coord-$offset) <= $by0 } {
-					$can coords $front $bx0 [expr {$by0+$sheight/2}] $bx1 $by1
+					$can coords $front $bx0 [expr {$by0+$sheight/2.0}] $bx1 $by1
 					$can coords $slider $sx0 $by0 $sx1 [expr {$by0+$sheight}]
 					if { $varvalue eq "" } { set $varname $to }
                 # elseif { ($slider_coord+$sheight/2) >= $by1 } 
 				} elseif { ($slider_coord+$sheight-$offset) >= $by1 } {
-					$can coords $front $bx0 [expr {$by1-$sheight/2}] $bx1 $by1
+					$can coords $front $bx0 [expr {$by1-$sheight/2.0}] $bx1 $by1
 					$can coords $slider $sx0 [expr {$by1-$sheight}] $sx1 $by1
 					if { $varvalue eq "" } { set $varname $from }
 				} else {
-					$can coords $front $bx0 [expr {$slider_coord-$offset+$sheight/2}] $bx1 $by1
+					$can coords $front $bx0 [expr {$slider_coord-$offset+$sheight/2.0}] $bx1 $by1
 					#$can move $slider 0 [expr {$slider_coord-$sheight/2-$sy0}]
                     $can move $slider 0 [expr {$slider_coord-$offset-$sy0}]
 					if { $varvalue eq "" } {
 						#set newcoord [expr {$from+($to-$from)*($by1-$slider_coord-$sheight/2)/($by1-$sheight-$by0)}]
-                        set newcoord [expr {$from+($to-$from)*($by1-$sheight-$slider_coord+$offset)/($by1-$sheight-$by0)}]
+                        set newcoord [expr {round($from+($to-$from)*double($by1-$sheight-$slider_coord+$offset)/double($by1-$sheight-$by0))}]
 						set $varname [number_in_range $newcoord {} $from $to $resolution $n_decimals]
 					}
 				} 
@@ -7255,7 +7255,7 @@ namespace eval ::dui {
 				if { $ns ne "" } {
 					set "${ns}::widgets(${main_tag}-crc)" $id
 					set "${ns}::widgets($main_tag)" $ids
-				}								
+				}
 			} else {
 				# HORIZONTAL SCALE
 				if { $plus_minus } {

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -448,7 +448,7 @@ namespace eval ::dui {
 	### PLATFORM SUB-ENSEMBLE ###
 	# System-related stuff
 	namespace eval platform {
-		namespace export hide_android_keyboard button_press button_long_press finger_down button_unpress \
+		namespace export hide_android_keyboard button_press button_long_press button_motion finger_down button_unpress \
 			xscale_factor yscale_factor rescale_x rescale_y translate_coordinates_finger_down_x translate_coordinates_finger_down_y \
 			is_fast_double_tap
 		namespace ensemble create
@@ -501,7 +501,15 @@ namespace eval ::dui {
 			}
 			return {<ButtonRelease-1>}
 		}
-		
+
+        proc button_motion {} {
+            global android 
+            if {$android == 1} {
+                return {<<FingerMotion>>}
+            }
+            return {<B1-Motion>}
+        }
+        
 		proc xscale_factor {} {
 			#global screen_size_width
 			return [expr {$::dui::_base_screen_width / [dui cget screen_size_width]}]
@@ -4709,6 +4717,11 @@ namespace eval ::dui {
 			relocate_text_wrt moveto pages
 		namespace ensemble create
 	
+        # Stores the initial tap position when dragging dscale sliders. Array keys are <first_page>,<dscale_tag>, and
+        # it contains the following value:
+        #   * an empty string when not in the middle of a drag/motion movement;
+        #   * the offset of the starting tap coordinate (x if horizontal, y if vertical) with respect to the left/top
+        #       coordinate of the slider shape, when in the middle of a drag/motion movement.
 		variable sliders
 		array set sliders {}
 		
@@ -5441,20 +5454,33 @@ namespace eval ::dui {
 		#		position of the slider within the scale, given by slider_coord.
 		#	2) If slider_coord is not specified, uses the value of $varname and moves the slider to match the value.
 		# Needs 'args' at the end because this is called from a 'trace add variable'.
-		proc dscale_moveto { page dscale_tag varname from to {resolution 1} {n_decimals 0} {slider_coord {}} args } {
-			set can [dui canvas]
+		proc dscale_moveto { page dscale_tag varname from to {resolution 1} {n_decimals 0} {slider_coord {}} \
+		        {slider_change {}} args } {
+            variable sliders
+            if { ![info exists sliders(${page},${dscale_tag})] } {
+                msg -WARNING [namespace current] scale_moveto: "scale on page '$page' with tag '$dscale_tag' not found"
+                return
+            }
+            set offset $sliders(${page},${dscale_tag})
+            # If we're in the middle of a slider drag motion and are here due to the trace add variable, do nothing.
+            if { $slider_coord eq "" && $offset ne "" } return
+            if { $offset eq "" } {
+                set offset 0
+            }
+            
+            set can [dui canvas]
 			set slider [dui item get $page "${dscale_tag}-crc"]
 			if { $slider eq "" } return
 			lassign [$can bbox $slider] sx0 sy0 sx1 sy1
 			# Return if the page is not currently visible
-			if {$sx0 eq "" } return		
+			if {$sx0 eq "" } return	
 			
 			set back [dui item get $page "${dscale_tag}-bck"]
 			set front [dui item get $page "${dscale_tag}-frn"]
-			if { $slider eq "" || $back eq "" || $front eq "" } {
+			if { $back eq "" || $front eq "" } {
 				return
 			}
-			
+
 			lassign [$can coords $back] bx0 by0 bx1 by1
 			lassign [$can coords $front] fx0 fy0 fx1 fy1
 				
@@ -5462,10 +5488,18 @@ namespace eval ::dui {
 			set sheight [expr {$sy1-$sy0}]
 			if { ($bx1 - $bx0) >= ($by1 -$by0) } {
 				set orient h
+                if { $slider_coord ne "" } {
+                    set slider_coord [dui::platform::translate_coordinates_finger_down_x $slider_coord]
+                }
 			} else {
 				set orient v
+                if { $slider_coord ne "" } {
+                    set slider_coord [dui::platform::translate_coordinates_finger_down_y $slider_coord]
+                }
 			}
-			
+                    
+msg -DEBUG [namespace current] dscale_moveto: "slider {$sx0 $sy0 $sx1 $sy1}, slider_coord=$slider_coord, slider_change=$slider_change, offset=$offset"
+                    
 			set varvalue ""
 			# If no slider_coord is given, reads the value from whatever is in variable $varname and transforms it
 			#	to a slider_coord value.
@@ -5476,62 +5510,112 @@ namespace eval ::dui {
 					set varvalue [number_in_range $from 0 $from $to $resolution $n_decimals]
 					set $varname $varvalue
 				}
-
+                
 				if { [string is double -strict $varvalue] } {
-					if { $varvalue <= $from } {
-						switch $orient h {set slider_coord $bx0} v {set slider_coord [expr {$by1-$sheight/2}]}
-					} elseif { $varvalue >= $to } {
-						switch $orient h {set slider_coord [expr {$bx1-$swidth/2}]} v {set slider_coord $by0 }
-					} elseif { $orient eq "h" } {
-						set slider_coord [expr {($bx0+$swidth/2)+($bx1-$bx0-$swidth)*$varvalue/($to-$from)}]
-					} else {
-						set slider_coord [expr {($by1-$sheight/2)+($by1-$by0-$sheight)*$varvalue/($from-$to)}]
-					}
+#					if { $varvalue <= $from } {
+#						switch $orient h {set slider_coord $bx0} v {set slider_coord [expr {$by1-$sheight/2}]}
+#					} elseif { $varvalue >= $to } {
+#						switch $orient h {set slider_coord [expr {$bx1-$swidth/2}]} v {set slider_coord $by0 }
+#					} elseif { $orient eq "h" } {
+#						set slider_coord [expr {($bx0+$swidth/2)+($bx1-$bx0-$swidth)*$varvalue/($to-$from)}]
+#					} else {
+#						set slider_coord [expr {($by1-$sheight/2)+($by1-$by0-$sheight)*$varvalue/($from-$to)}]
+#					}
+                    if { $varvalue <= $from } {
+                        switch $orient h {set slider_coord $bx0} v {set slider_coord [expr {$by1-$sheight}]}
+                    } elseif { $varvalue >= $to } {
+                        switch $orient h {set slider_coord [expr {$bx1-$swidth}]} v {set slider_coord $by0 }
+                    } elseif { $orient eq "h" } {
+                        set slider_coord [expr {$bx0+($bx1-$bx0-$swidth)*$varvalue/($to-$from)}]
+                    } else {
+                        set slider_coord [expr {($by1-$sheight)+($by1-$by0-$sheight)*$varvalue/($from-$to)}]
+                    }
 				} else {
 					return
 				}
+                
+msg -DEBUG [namespace current] dscale_moveto: "variable '$varname' value is $varvalue, which gets slider_coord=$slider_coord"
 			}
 			
 			# Move the slider to slider_coord (x-axis for horizontal scale, y-axis for vertical scale) 
 			if { $orient eq "h" } {
 				# Horizontal
-				if { ($slider_coord-$swidth/2) <= $bx0 } {
+                #if { ($slider_coord-$swidth/2) <= $bx0 } 
+				if { ($slider_coord-$offset) <= $bx0 } {
 					$can coords $front $bx0 $by0 [expr {$bx0+$swidth/2}] $by1
 					$can coords $slider $bx0 $sy0 [expr {$bx0+$swidth}] $sy1
 					if { $varvalue eq "" } { set $varname $from }
-				} elseif { $slider_coord >= ($bx1-$swidth/2) } {
+                #elseif { $slider_coord >= ($bx1-$swidth/2) }
+				} elseif { $slider_coord >= ($bx1-$swidth+$offset) } {
 					$can coords $front $bx0 $by0 [expr {$bx1-$swidth/2}] $by1
 					$can coords $slider [expr {$bx1-$swidth}] $sy0 $bx1 $sy1
 					if { $varvalue eq "" } { set $varname $to }
 				} else {
 					$can coords $front $bx0 $by0 $slider_coord $by1
-					$can move $slider [expr {$slider_coord-($swidth/2)-$sx0}] 0
+					#$can move $slider [expr {$slider_coord-($swidth/2)-$sx0}] 0
+                    $can move $slider [expr {$slider_coord-$sx0-$offset}] 0
 					if { $varvalue eq "" } {
-						set newcoord [expr {$from+($to-$from)*(($slider_coord-$swidth/2-$bx0)/($bx1-$swidth-$bx0))}]
-						set $varname [number_in_range $newcoord {} $from $to $resolution $n_decimals]  
+						#set newcoord [expr {$from+($to-$from)*(($slider_coord-$swidth/2-$bx0)/($bx1-$swidth-$bx0))}]
+                        set newcoord [expr {$from+($to-$from)*(($slider_coord-$offset-$bx0)/($bx1-$swidth-$bx0))}]
+                        set $varname [number_in_range $newcoord {} $from $to $resolution $n_decimals]
 					}
 				} 
 			} else {
 				# Vertical
-				if { ($slider_coord-$sheight/2) <= $by0 } {
+                #if { ($slider_coord-$sheight/2) <= $by0 } 
+				if { ($slider_coord-$offset) <= $by0 } {
 					$can coords $front $bx0 [expr {$by0+$sheight/2}] $bx1 $by1
 					$can coords $slider $sx0 $by0 $sx1 [expr {$by0+$sheight}]
 					if { $varvalue eq "" } { set $varname $to }
-				} elseif { ($slider_coord+$sheight/2) >= $by1 } {
+                # elseif { ($slider_coord+$sheight/2) >= $by1 } 
+				} elseif { ($slider_coord+$sheight+$offset) >= $by1 } {
 					$can coords $front $bx0 [expr {$by1-$sheight/2}] $bx1 $by1
 					$can coords $slider $sx0 [expr {$by1-$sheight}] $sx1 $by1
 					if { $varvalue eq "" } { set $varname $from }
 				} else {
 					$can coords $front $bx0 [expr {$slider_coord+$sheight/2}] $bx1 $by1
-					$can move $slider 0 [expr {$slider_coord-$sheight/2-$sy0}]
+					#$can move $slider 0 [expr {$slider_coord-$sheight/2-$sy0}]
+                    $can move $slider 0 [expr {$slider_coord-$offset-$sy0}]
 					if { $varvalue eq "" } {
-						set newcoord [expr {$from+($to-$from)*($by1-$slider_coord-$sheight/2)/($by1-$sheight-$by0)}]
+						#set newcoord [expr {$from+($to-$from)*($by1-$slider_coord-$sheight/2)/($by1-$sheight-$by0)}]
+                        set newcoord [expr {$from+($to-$from)*($by1-$slider_coord-$offset)/($by1-$sheight-$by0)}]
 						set $varname [number_in_range $newcoord {} $from $to $resolution $n_decimals]
 					}
 				} 
 			}
 		}
 		
+		proc dscale_start_motion { page dscale_tag orient coord } {
+            variable sliders
+            
+            set slider [dui item get $page "${dscale_tag}-crc"]
+            if { $slider eq "" } return
+            
+            set can [dui canvas]
+            lassign [$can bbox $slider] sx0 sy0 sx1 sy1
+            # Return if the page is not currently visible
+            if {$sx0 eq "" } return 
+
+            if { $orient eq "v" } {
+                set coord [dui::platform::translate_coordinates_finger_down_y $coord]
+                #set sliders(${page},${dscale_tag}) [expr {int($coord-($sy0+($sy1-$sy0)/2))}]
+                set sliders(${page},${dscale_tag}) [expr {int($coord-$sy0)}]
+            } else {
+                set coord [dui::platform::translate_coordinates_finger_down_x $coord]
+                #set sliders(${page},${dscale_tag}) [expr {int($coord-($sx0+($sx1-$sx0)/2))}]
+                set sliders(${page},${dscale_tag}) [expr {int($coord-$sx0)}]
+            }
+            
+            msg -DEBUG [namespace current] "dscale_start_motion: coord=$coord, sx0=$sx0, sx1=$sx1, Offset=$sliders(${page},${dscale_tag}) px"
+		}
+        
+        proc dscale_end_motion { page dscale_tag orient coord } {
+            variable sliders
+            set sliders(${page},${dscale_tag}) {}
+            
+            msg -DEBUG [namespace current] "dscale_end_motion: Offset=\{\}"
+        }
+        
 		# Paints each of the symbols of a drater control compound, according to the value of the underlying variable.
 		# Needs 'args' at the end because this is called from a 'trace add variable'.
 		proc drater_draw { page tag variable {n_ratings 5} {use_halfs 1} {min 0} {max 10} args } {
@@ -7101,7 +7185,7 @@ namespace eval ::dui {
 				set y [expr {$y+$pm_length}]
 				set y1 [expr {$y+$length-$pm_length*2}]
 				set yf [expr {$y1-$sliderlength/2}]
-				lappend moveto_cmd %y
+				lappend moveto_cmd %y %Y
 
 				if { $plus_minus } {
 					set id [$can create text $x [expr {$y-$pm_length*2/3}] -text "+" -anchor s -justify center \
@@ -7166,7 +7250,8 @@ namespace eval ::dui {
 				# Vertical circle slider
 				set id [$can create oval [expr {$x-$sliderlength/2}] [expr {$yf-$sliderlength/2}] \
 					[expr {$x+$sliderlength/2}] [expr {$yf+$sliderlength/2}] -fill $foreground \
-					-disabledfill $disabledforeground -width 0 -tags [list {*}$tags ${main_tag}-crc] -state hidden] 
+					-disabledfill $disabledforeground -width 0 -tags [list {*}$tags ${main_tag}-crc] -state hidden]
+                set ::dui::item::sliders([lindex $pages 0],${main_tag}) {}
 				$can bind ${main_tag}-crc <B1-Motion> $moveto_cmd
 				lappend ids $id			
 				if { $ns ne "" } {
@@ -7176,7 +7261,7 @@ namespace eval ::dui {
 			} else {
 				# HORIZONTAL SCALE
 				if { $plus_minus } {
-					set pm_length [dui platform rescale_x 40]
+					set pm_length [dui platform rescale_x 60]
 				}				
 				set length [dui platform rescale_x $length]
 				set sliderlength [dui platform rescale_x $sliderlength]
@@ -7186,7 +7271,7 @@ namespace eval ::dui {
 				set x1f [expr {$x+$sliderlength/2}]
 				set y1 $y
 				set y1f $y
-				lappend moveto_cmd %x
+				lappend moveto_cmd %x %X
 				
 				if { $plus_minus } {
 					set id [$can create text [expr {$x-$pm_length}] [expr {$y-3}] -text "-" -anchor w -justify left  \
@@ -7251,8 +7336,14 @@ namespace eval ::dui {
 				# Horizontal circle slider
 				set id [$can create oval [expr {$x1f-($sliderlength/2)}] [expr {$y1f-($sliderlength/2)}] \
 					[expr {$x1f+($sliderlength/2)}] [expr {$y1f+($sliderlength/2)}] -fill $foreground \
-					-disabledfill $disabledforeground -width 0 -tags [list {*}$tags ${main_tag}-crc] -state hidden] 
-				$can bind ${main_tag}-crc <B1-Motion> $moveto_cmd
+					-disabledfill $disabledforeground -width 0 -tags [list {*}$tags ${main_tag}-crc] -state hidden]
+                set ::dui::item::sliders([lindex $pages 0],${main_tag}) {}
+                
+                $can bind ${main_tag}-crc [dui platform button_press] [list ::dui::item::dscale_start_motion [lindex $pages 0] $main_tag $orient %x]
+                $can bind ${main_tag}-crc [dui platform button_unpress] [list ::dui::item::dscale_end_motion [lindex $pages 0] $main_tag $orient %x]
+                
+				#$can bind ${main_tag}-crc <B1-Motion> $moveto_cmd
+                $can bind ${main_tag}-crc [dui platform button_motion] $moveto_cmd
 				lappend ids $id			
 				if { $ns ne "" } {
 					set "${ns}::widgets(${main_tag}-crc)" $id
@@ -7260,7 +7351,7 @@ namespace eval ::dui {
 				}
 			}
 			
-			set update_cmd [lreplace $moveto_cmd end end ""]
+			set update_cmd [lreplace $moveto_cmd end-1 end {} {}]
 			trace add variable $var write $update_cmd
 			# Force initializing the slider position
 			dui page add_action $pages show $update_cmd
@@ -7526,7 +7617,7 @@ proc number_in_range { {value 0} {change 0} {min {}} {max {}} {resolution 0} {n_
 		set newvalue $max
 	} 
 	if { $resolution ne "" && $resolution != 0 } {
-		set newvalue [expr {int($newvalue/$resolution)*$resolution}]
+		set newvalue [expr {round($newvalue/$resolution)*$resolution}]
 	}
 	if { $n_decimals ne "" } {
 		set newvalue [format "%.${n_decimals}f" $newvalue]

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -848,7 +848,7 @@ namespace eval ::dui {
 	
 			default.dscale.orient horizontal
 			default.dscale.foreground "#4e85f4"
-            default.dscale.activeforeground "#4e85f4"
+			default.dscale.activeforeground "#4e85f4"
 			default.dscale.background "#7f879a"
 			default.dscale.sliderlength 75
 			
@@ -5456,20 +5456,20 @@ namespace eval ::dui {
 		#	2) If slider_coord is not specified, uses the value of $varname and moves the slider to match the value.
 		# Needs 'args' at the end because this is called from a 'trace add variable'.
 		proc dscale_moveto { page dscale_tag varname from to {resolution 1} {n_decimals 0} {slider_coord {}} \
-		        {slider_change {}} args } {
-            variable sliders
-            if { ![info exists sliders(${page},${dscale_tag})] } {
-                msg -WARNING [namespace current] scale_moveto: "scale on page '$page' with tag '$dscale_tag' not found"
-                return
-            }
-            set offset $sliders(${page},${dscale_tag})
-            # If we're in the middle of a slider drag motion and are here due to the trace add variable, do nothing.
-            if { $slider_coord eq "" && $offset ne "" } return
-            if { $offset eq "" } {
-                set offset 0
-            }
-            
-            set can [dui canvas]
+				{slider_change {}} args } {
+			variable sliders
+			if { ![info exists sliders(${page},${dscale_tag})] } {
+				msg -WARNING [namespace current] scale_moveto: "scale on page '$page' with tag '$dscale_tag' not found"
+				return
+			}
+			set offset $sliders(${page},${dscale_tag})
+			# If we're in the middle of a slider drag motion and are here due to the trace add variable, do nothing.
+			if { $slider_coord eq "" && $offset ne "" } return
+			if { $offset eq "" } {
+				set offset 0
+			}
+
+			set can [dui canvas]
 			set slider [dui item get $page "${dscale_tag}-crc"]
 			if { $slider eq "" } return
 			lassign [$can bbox $slider] sx0 sy0 sx1 sy1
@@ -5489,16 +5489,16 @@ namespace eval ::dui {
 			set sheight [expr {$sy1-$sy0}]
 			if { ($bx1 - $bx0) >= ($by1 -$by0) } {
 				set orient h
-                if { $slider_coord ne "" } {
-                    set slider_coord [dui::platform::translate_coordinates_finger_down_x $slider_coord]
-                }
+				if { $slider_coord ne "" } {
+					set slider_coord [dui::platform::translate_coordinates_finger_down_x $slider_coord]
+				}
 			} else {
 				set orient v
-                if { $slider_coord ne "" } {
-                    set slider_coord [dui::platform::translate_coordinates_finger_down_y $slider_coord]
-                }
+				if { $slider_coord ne "" } {
+					set slider_coord [dui::platform::translate_coordinates_finger_down_y $slider_coord]
+				}
 			}
-                    
+
 			set varvalue ""
 			# If no slider_coord is given, reads the value from whatever is in variable $varname and transforms it
 			#	to a slider_coord value.
@@ -5509,7 +5509,7 @@ namespace eval ::dui {
 					set varvalue [number_in_range $from 0 $from $to $resolution $n_decimals]
 					set $varname $varvalue
 				}
-                
+
 				if { [string is double -strict $varvalue] } {
 #					if { $varvalue <= $from } {
 #						switch $orient h {set slider_coord $bx0} v {set slider_coord [expr {$by1-$sheight/2}]}
@@ -5520,15 +5520,15 @@ namespace eval ::dui {
 #					} else {
 #						set slider_coord [expr {($by1-$sheight/2)+($by1-$by0-$sheight)*$varvalue/($from-$to)}]
 #					}
-                    if { $varvalue <= $from } {
-                        switch $orient h {set slider_coord $bx0} v {set slider_coord [expr {$by1-$sheight}]}
-                    } elseif { $varvalue >= $to } {
-                        switch $orient h {set slider_coord [expr {$bx1-$swidth}]} v {set slider_coord $by0 }
-                    } elseif { $orient eq "h" } {
-                        set slider_coord [expr {round($bx0+($bx1-$bx0-$swidth)*double($varvalue-$from)/double($to-$from))}]
-                    } else {
-                        set slider_coord [expr {round(($by1-$sheight)+($by1-$by0-$sheight)*double($varvalue-$from)/double($from-$to))}]
-                    }
+					if { $varvalue <= $from } {
+						switch $orient h {set slider_coord $bx0} v {set slider_coord [expr {$by1-$sheight}]}
+					} elseif { $varvalue >= $to } {
+						switch $orient h {set slider_coord [expr {$bx1-$swidth}]} v {set slider_coord $by0 }
+					} elseif { $orient eq "h" } {
+						set slider_coord [expr {round($bx0+($bx1-$bx0-$swidth)*double($varvalue-$from)/double($to-$from))}]
+					} else {
+						set slider_coord [expr {round(($by1-$sheight)+($by1-$by0-$sheight)*double($varvalue-$from)/double($from-$to))}]
+					}
 				} else {
 					return
 				}
@@ -5537,12 +5537,12 @@ namespace eval ::dui {
 			# Move the slider to slider_coord (x-axis for horizontal scale, y-axis for vertical scale) 
 			if { $orient eq "h" } {
 				# Horizontal
-                #if { ($slider_coord-$swidth/2) <= $bx0 } 
+				#if { ($slider_coord-$swidth/2) <= $bx0 } 
 				if { ($slider_coord-$offset) <= $bx0 } {
 					$can coords $front $bx0 $by0 [expr {$bx0+$swidth/2.0}] $by1
 					$can coords $slider $bx0 $sy0 [expr {$bx0+$swidth}] $sy1
 					if { $varvalue eq "" } { set $varname $from }
-                #elseif { $slider_coord >= ($bx1-$swidth/2) }
+				#elseif { $slider_coord >= ($bx1-$swidth/2) }
 				} elseif { $slider_coord >= ($bx1-$swidth+$offset) } {
 					$can coords $front $bx0 $by0 [expr {$bx1-$swidth/2.0}] $by1
 					$can coords $slider [expr {$bx1-$swidth}] $sy0 $bx1 $sy1
@@ -5550,110 +5550,113 @@ namespace eval ::dui {
 				} else {
 #					$can coords $front $bx0 $by0 $slider_coord $by1
 #					#$can move $slider [expr {$slider_coord-($swidth/2)-$sx0}] 0
-#                    $can move $slider [expr {$slider_coord-$sx0-$offset}] 0
+#					$can move $slider [expr {$slider_coord-$sx0-$offset}] 0
 #					if { $varvalue eq "" } {
 #						#set newcoord [expr {$from+($to-$from)*(($slider_coord-$swidth/2-$bx0)/($bx1-$swidth-$bx0))}]
-#                        set newcoord [expr {round($from+($to-$from)*(double($slider_coord-$offset-$bx0)/double($bx1-$swidth-$bx0)))}]
-#                        set $varname [number_in_range $newcoord {} $from $to $resolution $n_decimals]
+#						set newcoord [expr {round($from+($to-$from)*(double($slider_coord-$offset-$bx0)/double($bx1-$swidth-$bx0)))}]
+#						set $varname [number_in_range $newcoord {} $from $to $resolution $n_decimals]
 #					}
-                    
-                   if { $varvalue eq "" } {
-                       # Slider movement. Check we actually need to move if resolution is defined
-                       set varvalue [ifexists $varname $from]
-                       if { $varvalue eq "" } {
-                           set varvalue $from
-                       }
-                       set newvalue [expr {$from+($to-$from)*(double($slider_coord-$offset-$bx0)/double($bx1-$swidth-$bx0))}]
-                       set newvalue [number_in_range $newvalue {} $from $to $resolution $n_decimals]
-                       
-                       if { abs($newvalue - $varvalue) > 1e-10 } {
-                           $can coords $front $bx0 $by0 $slider_coord $by1
-                           $can move $slider [expr {$slider_coord-$sx0-$offset}] 0
-                           if { $varname ne "" } {
-                                set $varname $newvalue
-                           }
-                       }
-                   } else {
-                       # Direct move to
-                       $can coords $front $bx0 $by0 $slider_coord $by1
-                       $can move $slider [expr {$slider_coord-$sx0-$offset}] 0
-#                       
-#                        set newvalue [expr {round($from+($to-$from)*(double($slider_coord-$offset-$bx0)/double($bx1-$swidth-$bx0)))}]
-#                        set $varname [number_in_range $newvalue {} $from $to $resolution $n_decimals]
-                   }
-				} 
-			} else {
+					if { $varvalue eq "" } {
+						# Slider movement. Check we actually need to move if resolution is defined
+						set varvalue [ifexists $varname $from]
+						if { $varvalue eq "" } {
+							set varvalue $from
+						}
+						set newvalue [expr {$from+($to-$from)*(double($slider_coord-$offset-$bx0)/double($bx1-$swidth-$bx0))}]
+						set newvalue [number_in_range $newvalue {} $from $to $resolution $n_decimals]
+
+						if { abs($newvalue - $varvalue) > 1e-10 } {
+							$can coords $front $bx0 $by0 $slider_coord $by1
+							$can move $slider [expr {$slider_coord-$sx0-$offset}] 0
+							if { $varname ne "" } {
+								set $varname $newvalue
+							}
+						}
+					} else {
+						# Direct move to
+						$can coords $front $bx0 $by0 $slider_coord $by1
+						$can move $slider [expr {$slider_coord-$sx0-$offset}] 0
+						#
+						# set newvalue [expr {round($from+($to-$from)*(double($slider_coord-$offset-$bx0)/double($bx1-$swidth-$bx0)))}]
+						# set $varname [number_in_range $newvalue {} $from $to $resolution $n_decimals]
+					}
+					}
+					} else {
 				# Vertical
-                #if { ($slider_coord-$sheight/2) <= $by0 } 
+				#if { ($slider_coord-$sheight/2) <= $by0 }
 				if { ($slider_coord-$offset) <= $by0 } {
 					$can coords $front $bx0 [expr {$by0+$sheight/2.0}] $bx1 $by1
 					$can coords $slider $sx0 $by0 $sx1 [expr {$by0+$sheight}]
-					if { $varvalue eq "" } { set $varname $to }
-                # elseif { ($slider_coord+$sheight/2) >= $by1 } 
+					if { $varvalue eq "" } { 
+						set $varname $to
+					}
+				# elseif { ($slider_coord+$sheight/2) >= $by1 }
 				} elseif { ($slider_coord+$sheight-$offset) >= $by1 } {
 					$can coords $front $bx0 [expr {$by1-$sheight/2.0}] $bx1 $by1
 					$can coords $slider $sx0 [expr {$by1-$sheight}] $sx1 $by1
-					if { $varvalue eq "" } { set $varname $from }
+					if { $varvalue eq "" } { 
+						set $varname $from
+					}
 				} else {
 #					$can coords $front $bx0 [expr {$slider_coord-$offset+$sheight/2.0}] $bx1 $by1
 #					#$can move $slider 0 [expr {$slider_coord-$sheight/2-$sy0}]
-#                    $can move $slider 0 [expr {$slider_coord-$offset-$sy0}]
+#					$can move $slider 0 [expr {$slider_coord-$offset-$sy0}]
 #					if { $varvalue eq "" } {
 #						#set newcoord [expr {$from+($to-$from)*($by1-$slider_coord-$sheight/2)/($by1-$sheight-$by0)}]
-#                        set newcoord [expr {round($from+($to-$from)*double($by1-$sheight-$slider_coord+$offset)/double($by1-$sheight-$by0))}]
+#						set newcoord [expr {round($from+($to-$from)*double($by1-$sheight-$slider_coord+$offset)/double($by1-$sheight-$by0))}]
 #						set $varname [number_in_range $newcoord {} $from $to $resolution $n_decimals]
 #					}
-                    if { $varvalue eq "" } {
-                        # Slider movement. Check we actually need to move if resolution is defined
-                        set varvalue [ifexists $varname $from]
-                        if { $varvalue eq "" } {
-                            set varvalue $from
-                        }
-                        set newvalue [expr {$from+($to-$from)*double($by1-$sheight-$slider_coord+$offset)/double($by1-$sheight-$by0)}]
-                        set newvalue [number_in_range $newvalue {} $from $to $resolution $n_decimals]
-                        if { abs($newvalue - $varvalue) > 1e-10 } {
-                            $can coords $front $bx0 [expr {$slider_coord-$offset+$sheight/2.0}] $bx1 $by1
-                            $can move $slider 0 [expr {$slider_coord-$offset-$sy0}]
-                            if { $varname ne "" } {
-                                set $varname $newvalue
-                            }
-                        }
-                    } else {
-                        # Direct move to
-                        $can coords $front $bx0 [expr {$slider_coord-$offset+$sheight/2.0}] $bx1 $by1
-                        $can move $slider 0 [expr {$slider_coord-$offset-$sy0}]
-                    }
-				} 
+					if { $varvalue eq "" } {
+						# Slider movement. Check we actually need to move if resolution is defined
+						set varvalue [ifexists $varname $from]
+						if { $varvalue eq "" } {
+							set varvalue $from
+						}
+						set newvalue [expr {$from+($to-$from)*double($by1-$sheight-$slider_coord+$offset)/double($by1-$sheight-$by0)}]
+						set newvalue [number_in_range $newvalue {} $from $to $resolution $n_decimals]
+						if { abs($newvalue - $varvalue) > 1e-10 } {
+							$can coords $front $bx0 [expr {$slider_coord-$offset+$sheight/2.0}] $bx1 $by1
+							$can move $slider 0 [expr {$slider_coord-$offset-$sy0}]
+							if { $varname ne "" } {
+								set $varname $newvalue
+							}
+						}
+					} else {
+							# Direct move to
+							$can coords $front $bx0 [expr {$slider_coord-$offset+$sheight/2.0}] $bx1 $by1
+							$can move $slider 0 [expr {$slider_coord-$offset-$sy0}]
+						}
+					}
 			}
-		}
+					}
 		
 		proc dscale_start_motion { page dscale_tag orient coord } {
-            variable sliders
-            
-            set slider [dui item get $page "${dscale_tag}-crc"]
-            if { $slider eq "" } return
-            
-            set can [dui canvas]
-            lassign [$can bbox $slider] sx0 sy0 sx1 sy1
-            # Return if the page is not currently visible
-            if {$sx0 eq "" } return 
+			variable sliders
 
-            if { $orient eq "v" } {
-                set coord [dui::platform::translate_coordinates_finger_down_y $coord]
-                #set sliders(${page},${dscale_tag}) [expr {int($coord-($sy0+($sy1-$sy0)/2))}]
-                set sliders(${page},${dscale_tag}) [expr {int($coord-$sy0)}]
-            } else {
-                set coord [dui::platform::translate_coordinates_finger_down_x $coord]
-                #set sliders(${page},${dscale_tag}) [expr {int($coord-($sx0+($sx1-$sx0)/2))}]
-                set sliders(${page},${dscale_tag}) [expr {int($coord-$sx0)}]
-            }
+			set slider [dui item get $page "${dscale_tag}-crc"]
+			if { $slider eq "" } return
+
+			set can [dui canvas]
+			lassign [$can bbox $slider] sx0 sy0 sx1 sy1
+			# Return if the page is not currently visible
+			if {$sx0 eq "" } return
+
+			if { $orient eq "v" } {
+				set coord [dui::platform::translate_coordinates_finger_down_y $coord]
+				#set sliders(${page},${dscale_tag}) [expr {int($coord-($sy0+($sy1-$sy0)/2))}]
+				set sliders(${page},${dscale_tag}) [expr {int($coord-$sy0)}]
+			} else {
+				set coord [dui::platform::translate_coordinates_finger_down_x $coord]
+				#set sliders(${page},${dscale_tag}) [expr {int($coord-($sx0+($sx1-$sx0)/2))}]
+				set sliders(${page},${dscale_tag}) [expr {int($coord-$sx0)}]
+			}
 		}
-        
-        proc dscale_end_motion { page dscale_tag orient coord } {
-            variable sliders
-            set sliders(${page},${dscale_tag}) {}
-        }
-        
+
+		proc dscale_end_motion { page dscale_tag orient coord } {
+			variable sliders
+			set sliders(${page},${dscale_tag}) {}
+		}
+
 		# Paints each of the symbols of a drater control compound, according to the value of the underlying variable.
 		# Needs 'args' at the end because this is called from a 'trace add variable'.
 		proc drater_draw { page tag variable {n_ratings 5} {use_halfs 1} {min 0} {max 10} args } {

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -5559,14 +5559,19 @@ namespace eval ::dui {
                     
                    if { $varvalue eq "" } {
                        # Slider movement. Check we actually need to move if resolution is defined
-                       set varvalue [subst \$$varname]
-                       set newvalue [expr {round($from+($to-$from)*(double($slider_coord-$offset-$bx0)/double($bx1-$swidth-$bx0)))}]
+                       set varvalue [ifexists $varname $from]
+                       if { $varvalue eq "" } {
+                           set varvalue $from
+                       }
+                       set newvalue [expr {$from+($to-$from)*(double($slider_coord-$offset-$bx0)/double($bx1-$swidth-$bx0))}]
                        set newvalue [number_in_range $newvalue {} $from $to $resolution $n_decimals]
                        
-                       if { abs($newvalue - $varvalue) > 1e-5 } {
+                       if { abs($newvalue - $varvalue) > 1e-10 } {
                            $can coords $front $bx0 $by0 $slider_coord $by1
                            $can move $slider [expr {$slider_coord-$sx0-$offset}] 0
-                           set $varname $newvalue
+                           if { $varname ne "" } {
+                                set $varname $newvalue
+                           }
                        }
                    } else {
                        # Direct move to
@@ -5600,14 +5605,18 @@ namespace eval ::dui {
 #					}
                     if { $varvalue eq "" } {
                         # Slider movement. Check we actually need to move if resolution is defined
-                        set varvalue [subst \$$varname]
-                        set newvalue [expr {round($from+($to-$from)*double($by1-$sheight-$slider_coord+$offset)/double($by1-$sheight-$by0))}]
+                        set varvalue [ifexists $varname $from]
+                        if { $varvalue eq "" } {
+                            set varvalue $from
+                        }
+                        set newvalue [expr {$from+($to-$from)*double($by1-$sheight-$slider_coord+$offset)/double($by1-$sheight-$by0)}]
                         set newvalue [number_in_range $newvalue {} $from $to $resolution $n_decimals]
-                         
-                        if { abs($newvalue - $varvalue) > 1e-5 } {
+                        if { abs($newvalue - $varvalue) > 1e-10 } {
                             $can coords $front $bx0 [expr {$slider_coord-$offset+$sheight/2.0}] $bx1 $by1
                             $can move $slider 0 [expr {$slider_coord-$offset-$sy0}]
-                            set $varname $newvalue
+                            if { $varname ne "" } {
+                                set $varname $newvalue
+                            }
                         }
                     } else {
                         # Direct move to
@@ -7650,7 +7659,7 @@ proc number_in_range { {value 0} {change 0} {min {}} {max {}} {resolution 0} {n_
 		set newvalue $max
 	} 
 	if { $resolution ne "" && $resolution != 0 } {
-		set newvalue [expr {round($newvalue/$resolution)*$resolution}]
+		set newvalue [expr {round(double($newvalue)/double($resolution))*double($resolution)}]
 	}
 	if { $n_decimals ne "" } {
 		set newvalue [format "%.${n_decimals}f" $newvalue]

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -5548,14 +5548,34 @@ namespace eval ::dui {
 					$can coords $slider [expr {$bx1-$swidth}] $sy0 $bx1 $sy1
 					if { $varvalue eq "" } { set $varname $to }
 				} else {
-					$can coords $front $bx0 $by0 $slider_coord $by1
-					#$can move $slider [expr {$slider_coord-($swidth/2)-$sx0}] 0
-                    $can move $slider [expr {$slider_coord-$sx0-$offset}] 0
-					if { $varvalue eq "" } {
-						#set newcoord [expr {$from+($to-$from)*(($slider_coord-$swidth/2-$bx0)/($bx1-$swidth-$bx0))}]
-                        set newcoord [expr {round($from+($to-$from)*(double($slider_coord-$offset-$bx0)/double($bx1-$swidth-$bx0)))}]
-                        set $varname [number_in_range $newcoord {} $from $to $resolution $n_decimals]
-					}
+#					$can coords $front $bx0 $by0 $slider_coord $by1
+#					#$can move $slider [expr {$slider_coord-($swidth/2)-$sx0}] 0
+#                    $can move $slider [expr {$slider_coord-$sx0-$offset}] 0
+#					if { $varvalue eq "" } {
+#						#set newcoord [expr {$from+($to-$from)*(($slider_coord-$swidth/2-$bx0)/($bx1-$swidth-$bx0))}]
+#                        set newcoord [expr {round($from+($to-$from)*(double($slider_coord-$offset-$bx0)/double($bx1-$swidth-$bx0)))}]
+#                        set $varname [number_in_range $newcoord {} $from $to $resolution $n_decimals]
+#					}
+                    
+                   if { $varvalue eq "" } {
+                       # Slider movement. Check we actually need to move if resolution is defined
+                       set varvalue [subst \$$varname]
+                       set newvalue [expr {round($from+($to-$from)*(double($slider_coord-$offset-$bx0)/double($bx1-$swidth-$bx0)))}]
+                       set newvalue [number_in_range $newvalue {} $from $to $resolution $n_decimals]
+                       
+                       if { abs($newvalue - $varvalue) > 1e-5 } {
+                           $can coords $front $bx0 $by0 $slider_coord $by1
+                           $can move $slider [expr {$slider_coord-$sx0-$offset}] 0
+                           set $varname $newvalue
+                       }
+                   } else {
+                       # Direct move to
+                       $can coords $front $bx0 $by0 $slider_coord $by1
+                       $can move $slider [expr {$slider_coord-$sx0-$offset}] 0
+#                       
+#                        set newvalue [expr {round($from+($to-$from)*(double($slider_coord-$offset-$bx0)/double($bx1-$swidth-$bx0)))}]
+#                        set $varname [number_in_range $newvalue {} $from $to $resolution $n_decimals]
+                   }
 				} 
 			} else {
 				# Vertical
@@ -5570,14 +5590,30 @@ namespace eval ::dui {
 					$can coords $slider $sx0 [expr {$by1-$sheight}] $sx1 $by1
 					if { $varvalue eq "" } { set $varname $from }
 				} else {
-					$can coords $front $bx0 [expr {$slider_coord-$offset+$sheight/2.0}] $bx1 $by1
-					#$can move $slider 0 [expr {$slider_coord-$sheight/2-$sy0}]
-                    $can move $slider 0 [expr {$slider_coord-$offset-$sy0}]
-					if { $varvalue eq "" } {
-						#set newcoord [expr {$from+($to-$from)*($by1-$slider_coord-$sheight/2)/($by1-$sheight-$by0)}]
-                        set newcoord [expr {round($from+($to-$from)*double($by1-$sheight-$slider_coord+$offset)/double($by1-$sheight-$by0))}]
-						set $varname [number_in_range $newcoord {} $from $to $resolution $n_decimals]
-					}
+#					$can coords $front $bx0 [expr {$slider_coord-$offset+$sheight/2.0}] $bx1 $by1
+#					#$can move $slider 0 [expr {$slider_coord-$sheight/2-$sy0}]
+#                    $can move $slider 0 [expr {$slider_coord-$offset-$sy0}]
+#					if { $varvalue eq "" } {
+#						#set newcoord [expr {$from+($to-$from)*($by1-$slider_coord-$sheight/2)/($by1-$sheight-$by0)}]
+#                        set newcoord [expr {round($from+($to-$from)*double($by1-$sheight-$slider_coord+$offset)/double($by1-$sheight-$by0))}]
+#						set $varname [number_in_range $newcoord {} $from $to $resolution $n_decimals]
+#					}
+                    if { $varvalue eq "" } {
+                        # Slider movement. Check we actually need to move if resolution is defined
+                        set varvalue [subst \$$varname]
+                        set newvalue [expr {round($from+($to-$from)*double($by1-$sheight-$slider_coord+$offset)/double($by1-$sheight-$by0))}]
+                        set newvalue [number_in_range $newvalue {} $from $to $resolution $n_decimals]
+                         
+                        if { abs($newvalue - $varvalue) > 1e-5 } {
+                            $can coords $front $bx0 [expr {$slider_coord-$offset+$sheight/2.0}] $bx1 $by1
+                            $can move $slider 0 [expr {$slider_coord-$offset-$sy0}]
+                            set $varname $newvalue
+                        }
+                    } else {
+                        # Direct move to
+                        $can coords $front $bx0 [expr {$slider_coord-$offset+$sheight/2.0}] $bx1 $by1
+                        $can move $slider 0 [expr {$slider_coord-$offset-$sy0}]
+                    }
 				} 
 			}
 		}

--- a/documentation/decent_user_interface.md
+++ b/documentation/decent_user_interface.md
@@ -133,6 +133,7 @@
   - [dui add listbox](#dui_add_listbox)
   - [dui add dcheckbox](#dui_add_dcheckbox)
   - [dui add scale](#dui_add_scale)
+  - [dui add dscale](#dui_add_dscale)
   - [dui add drater](#dui_add_drater)
   - [dui add graph](#dui_add_graph)
 - `dui args`
@@ -1705,6 +1706,9 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 > >Optional callback code to run when the checkbox is clicked.
 > >In addition to the usual substituttions, **%NS** will be replaced by the page namespace name, or the empty string if no page namespace is used.
 
+
+<a name="dui_add_scale"></a>
+
 **dui add scale**  _pages x y ?-option value ...?_
 
 >Create a Tk scale widget and add it to the requested  _pages_  at coordinates  _{x, y}_ . 
@@ -1813,7 +1817,7 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 
 >**-plus_minus**  _true_or_false_
 
-> >Whether to show (default) or hide the plus and minus on the line extremes.
+> >Whether to show (default) or hide the plus and minus on the line extremes. Tapping the plus or minus symbols increases/reduces the variable value by  _smallincrement_ . Tapping them fast three times increases/reduces the variable value by  _bigincrement_ .
 
 >**-default**  _number_
 

--- a/documentation/decent_user_interface.md
+++ b/documentation/decent_user_interface.md
@@ -31,6 +31,7 @@
   - dui platform button_press
   - dui platform button_long_press
   - dui platform finger_down
+  - dui platform finger_motion
   - dui platform button_unpress
   - dui platform xscale_factor
   - dui platform yscale_factor
@@ -169,7 +170,7 @@ toolkit basics), and the [TkDocs online tutorial](https://tkdocs.com/).
 ## Revision History
 
 * 2021-04-10 – Initial writing by [Enrique Bengoechea](https://github.com/ebengoechea)
-* 2021-04-11 - 2021-06-27 - Rewrite while the API evolves through nightly & beta, by [Enrique Bengoechea](https://github.com/ebengoechea)
+* 2021-04-11 - 2021-07-18 - Rewrite while the API evolves through nightly & beta, by [Enrique Bengoechea](https://github.com/ebengoechea)
 
 <a name="history"></a>
 
@@ -1721,7 +1722,7 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 
 >Return the list of all canvas IDs that form the scale compound. The command also adds (if applicable) the following named tags to the canvas, and the same keys in the widgets page namespace array: 
 
-> >&lt;main_tag&gt;: the slider circle;
+> >&lt;main_tag&gt;-crc: the slider circle;
 
 > >&lt;main_tag&gt;-bck: the background line;
 
@@ -1778,6 +1779,10 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 
 > >The fill color of the foreground scale line (the part of the line that marks the variable value, i.e. the left section in horizontal scales, and the bottom section in vertical scales), and the slider circle, when the control is enabled.
 
+>**-activeforeground**  _color_
+
+> >The fill color of the slider circle when it is active (i.e. when it is tapped for moving it).
+
 >**-disabledforeground**  _color_
 
 > >The fill color of the foreground scale line and the slider circle when the control is disabled.
@@ -1806,7 +1811,7 @@ A few **dui add** commands just offer convenience shorthands to other commands, 
 
 > >Passed to the full page number editor, and used when tapping repeteadly the plus/minus (currently implemented as triple-click, but may change).
 
->**-plus_minus**  _true_of_false_
+>**-plus_minus**  _true_or_false_
 
 > >Whether to show (default) or hide the plus and minus on the line extremes.
 


### PR DESCRIPTION
This PR completes the DUI version of scales, called "dscales". They offer an alternative to Tk scale widgets, built from canvas primitives. Previous versions of "dscale" worked on PC but failed on android. Now they should work on all platforms, plus several improvements have been made to make the `-resolution` option work correctly for setting discrete values.

A new command `dui platform button_motion` has been introduced, that, similar to analougosly named commands, returns the virtual event corresponding to button or finger motions depending on the current platform.

To reviewers: there is no code currently in the app that shows a "dscale", so it can be tested. To test it, I suggest to manually replace line  1102 in file `skins/Insight/skin.tcl`:
```tcl
add_de1_widget "steam steam_1 steam_3" scale 10 1436 {} -from 40 -to 250 -background "#e8e1df" -borderwidth 1 -showvalue 0  -bigincrement 100 -resolution 10 -length [rescale_x_skin 2000] -width [rescale_y_skin 150] -variable ::settings(steam_flow) -font Helv_10_bold -sliderlength [rescale_x_skin 500] -relief flat -command {set_steam_flow} -orient horizontal -foreground #FFFFFF -troughcolor "#d7d9e5" -borderwidth 0  -highlightthickness 0
```
by this one:
```tcl
dui add dscale "steam steam_1 steam_3" 40 1510 {} -from 40 -to 250 -bigincrement 100 -smallincrement 10 -resolution 10 -length 1950 -width 14 -sliderlength 120 -variable ::settings(steam_flow) -command {set_steam_flow} -orient horizontal
```

which produces this:
![image](https://user-images.githubusercontent.com/60866/126077437-f014d27d-3d58-4622-bce8-5cd2aadf0ebd.png)
﻿