### PR TITLE
Added plugin for old_lcd_disable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,3 +27,6 @@
 [submodule "de1plus/plugins/DPx_Screen_Saver"]
 	path = de1plus/plugins/DPx_Screen_Saver
 	url = https://github.com/Damian-AU/DPx_Screen_Saver
+[submodule "de1plus/plugins/old_lcd_disable"]
+	path = de1plus/plugins/old_lcd_disable
+	url = https://github.com/bkeller2/old_lcd_disable


### PR DESCRIPTION
Pretty simple plugin to restore the previous LCD scale functionality that were changed in 64ab57cca3aa1111e429b02cb18b5eaa096603f9. 

It was tested both on desktop (macOS) and on a tablet and seemed to have no issues.