### PR TITLE
add settings entry to disable Decent Scale LCD on sleep

### DIFF
--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -35,10 +35,9 @@ proc scale_disable_lcd {} {
 		}
 	} elseif {$::settings(scale_type) == "decentscale"} {
 		
-		set do_this 0
-		if {$do_this == 1} {
-			# disabled the LCD off for Decent Scale, so that we don't give false impression tha the scale is off
-			# ideally in future firmware we can find out if they are on usb power, and disable LEDs if they are
+		if {$::settings(disable_decent_scale_lcd_on_sleep) == 1} {
+			# by default, disabled the LCD off for Decent Scale, so that we don't give false impression tha the scale is off
+			# ideally in future firmware we can find out if they are on usb power, and disable LEDs if they are. until then, disable only if set so in settings
 			decentscale_disable_lcd
 			# double-sending command, half a second later, because sometimes the decent scale command buffer has not finished the previous command and drops the next one
 			after 500 decentscale_disable_lcd

--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -451,6 +451,7 @@ array set ::settings {
 	create_legacy_shotfiles 0
 
 	show_scale_notifications 1
+	disable_decent_scale_lcd_on_sleep 0
 }
 
 # default de1plus skin


### PR DESCRIPTION
As far as I understood the discussion between @decentjohn and @ebengoechea in Diaspora, a setting to re-enable disabling the Decent Scale LCD when the machine goes to sleep would be acceptable. Since I really miss this tiny change, here's a PR for it.