### PR TITLE
DUI dialogs

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -4815,16 +4815,23 @@ namespace eval ::dui {
 						set w [$can itemcget $item -window]
 						# "try" as not all widgets support the -state option (e.g. Graph)	
 						try {
-							set dialog_states($item) [$w cget -state]
-							$w configure -state disabled
+							set state [$w cget -state]
+							set dialog_states($item) $state
+							if { $state ne "hidden" } {
+								$w configure -state disabled
+							}
 						} on error err {
 							#msg -WARNING [namespace current] add: "widget of type '[winfo class $w]' doesn't support the -state option"
-							set dialog_states($item) [$can itemcget $item -state]
-							$can itemconfigure $item -state disabled
+							set state [$can itemcget $item -state]
+							set dialog_states($item) $state
+							if { $state ne "hidden" } {
+								$can itemconfigure $item -state disabled
+							}
 						}
 					} else {
-						set dialog_states($item) [$can itemcget $item -state]
-						if { $disable_items } {
+						set state [$can itemcget $item -state]
+						set dialog_states($item) $state
+						if { $disable_items && $state ne "hidden" } {
 							$can itemconfigure $item -state disabled
 						}
 					}

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -4083,6 +4083,8 @@ namespace eval ::dui {
 		#  -style to apply the default aspects of the provided style
 		#  -bg_img background image file to use
 		#  -bg_color background color to use, in case no background image is defined
+		#  -bg_shape the shape to use as background, if -bg_img is not defined. Default is rectangle, but can take any
+		#		other as accepted by 'dui add shape'.
 		#  -skin passed to ::add_de1_page if necessary
 		#  -namespace either a value that can be a boolean, or a list of namespaces names.
 		#		If the option is not specified, uses ::dui::create_page_namespaces as default. Then:
@@ -4095,7 +4097,6 @@ namespace eval ::dui {
 		#  -type: the type of the page, either "default" or "dialog". 
 		#  -bbox: for pages with type=dialog, the initial bounding box coordinates {x0 y0 x1 y1} of the dialog rectangle.
 		#		If not specified for a dialog-type page, it defaults to full page.
-		# TODO -style/-shape
 		
 		proc add { pages args } {
 			variable pages_data
@@ -4943,7 +4944,7 @@ namespace eval ::dui {
 		#	-anchor <anchor>: Specifies how the reference point given in -coords should be anchored to, default is "nw".
 		#	-size {width height}: A list with the target width and height of the dialog page, on the base 2560x1600 space 
 		#		or in percentage of that space (if >0 & <1). The dialog page will be resized as needed, by recreating the page.
-		#	-return_callback <proc_name>: The name of a tcl function that will process the parameters returned by the dialog 
+		#	-return_callback <proc_name>: Fully qualified name of a tcl function that will process the parameters returned by the dialog 
 		#		when it is closed. This callback function must have arguments that match those returned by the
 		#		dui::page::close_dialog call in the dialog code. 
 		#		If this is empty, no special processing is done. This can work, for example, if the dialog is used to

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -4619,33 +4619,12 @@ namespace eval ::dui {
 			
 			catch { delay_screen_saver }
 			
-			set page_to_hide [current]
-
-			set reload [dui::args::get_option -reload 0 1]
-			if { $current_page eq $page_to_show && ![string is true $reload] } {
-				#msg -NOTICE [namespace current] load "returning because current_page == $page_to_show"
-				return 
-			}
-			
-			set hide_ns [get_namespace $page_to_hide]
-			set show_ns [get_namespace $page_to_show]
-			
-			if { $page_to_hide eq "" } {
-				set hide_page_type ""
-			} else {
-				set hide_page_type [type $page_to_hide]
-			}
-			set show_page_type [type $page_to_show]
-			if { $show_page_type eq "dialog" && $hide_page_type eq "dialog" } {
-				msg -WARNING [namespace current] load: "only one dialog page can be visible, can't move from dialog '$page_to_hide' to dialog '$page_to_show'"
-				return
-			}
-			
 			# run general load actions (same for all pages) in the global context. 
 			# If 1 or a string is returned, the loading process continues. 
 			# If it's a string that matches a page name, the page to show is changed to that one. 
 			# If 0 is returned, the loading process is interrupted.
 			# Note that this time we don't use [string is true] as "off" is evaluated as boolean...
+			set page_to_hide [current]
 			foreach action [actions {} load] {
 				lappend action $page_to_hide $page_to_show
 				set action_result [uplevel #0 $action]
@@ -4658,6 +4637,26 @@ namespace eval ::dui {
 						set page_to_show $action_result	
 					}
 				}
+			}
+
+			set reload [dui::args::get_option -reload 0 1]
+			if { $current_page eq $page_to_show && ![string is true $reload] } {
+				msg -NOTICE [namespace current] load "returning because current_page == $page_to_show"
+				return 
+			}
+			
+			set hide_ns [get_namespace $page_to_hide]
+			set show_ns [get_namespace $page_to_show]
+			if { $page_to_hide eq "" } {
+				set hide_page_type ""
+			} else {
+				set hide_page_type [type $page_to_hide]
+			}
+			set show_page_type [type $page_to_show]
+			
+			if { $show_page_type eq "dialog" && $hide_page_type eq "dialog" } {
+				msg -WARNING [namespace current] load: "only one dialog page can be visible, can't move from dialog '$page_to_hide' to dialog '$page_to_show'"
+				return
 			}
 			
 			msg [namespace current] load "$page_to_hide -> $page_to_show"
@@ -4923,6 +4922,8 @@ namespace eval ::dui {
 			#msg [namespace current] "Switched to page: $page_to_show [stacktrace]"
 		}
 		
+		# A one-liner to conditionally load a page only if the specified widget is enabled. Useful for commands run
+		# when double-tapping an entry box.
 		proc load_if_widget_enabled { widget args } {
 			if { [$widget cget -state] eq "normal" } {
 				load {*}$args

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -3940,7 +3940,7 @@ namespace eval ::dui {
 				set y1 [expr {$y+$height}]
 			} 
 			
-			if { [llength $largs] > 0 && [string is entier [lindex $largs 0]] } {
+			if { [llength $largs] > 0 && [string is double [lindex $largs 0]] } {
 				if { $x1 <= 0 } {
 					set x1 [dui::page::calc_x $pages [lindex $largs 0] $rescale]
 					set largs [lrange $largs 1 end]
@@ -3948,7 +3948,7 @@ namespace eval ::dui {
 					msg -WARNING [namespace current] process_sizes: "conflicting width and x1 arguments specified"
 				}
 				
-				if { [llength $largs] > 0 && [string is entier [lindex $largs 0]] } {
+				if { [llength $largs] > 0 && [string is double [lindex $largs 0]] } {
 					if { $y1 <= 0 } {
 						set y1 [dui::page::calc_x $pages [lindex $largs 0] $rescale]
 						set largs [lrange $largs 1 end]
@@ -6693,7 +6693,7 @@ namespace eval ::dui {
 			
 			set coords {}
 			set i 0
-			while { [llength $args] > 0 && [string is entier [lindex $args 0]] } {
+			while { [llength $args] > 0 && [string is double [lindex $args 0]] } {
 				if { $i % 2 == 0 } {
 					set coord [dui::page::calc_x $pages [lindex $args 0]]
 				} else {
@@ -6971,18 +6971,19 @@ msg "DUI ADD SHAPE outline_tags=[list ${main_tag}-out {*}[lrange $tags 1 end]]"
 				set y1 [expr {$y+$bheight}]
 			}		 
 			
-			if { [llength $args] > 0 && [string is entier [lindex $args 0]] } {
+			if { [llength $args] > 0 && [string is double [lindex $args 0]] } {
 				if { $x1 <= 0 } {
 					set x1 [dui::page::calc_x $first_page [lindex $args 0] 0]
 					set args [lrange $args 1 end]
 				}
 			}
-			if { [llength $args] > 0 && [string is entier [lindex $args 0]] } {
+			if { [llength $args] > 0 && [string is double [lindex $args 0]] } {
 				if { $y1 <= 0 } {
-					set y1 [dui::page::calc_x $first_page [lindex $args 0] 0]
+					set y1 [dui::page::calc_y $first_page [lindex $args 0] 0]
 					set args [lrange $args 1 end]
 				}				
 			}
+						
 			if { $x1 <= 0 } {
 				set x1 [expr {$x+100}]
 			}
@@ -6994,6 +6995,7 @@ msg "DUI ADD SHAPE outline_tags=[list ${main_tag}-out {*}[lrange $tags 1 end]]"
 			if { $anchor ne "nw" } {
 				lassign [dui::item::anchor_coords $anchor $x $y [expr {$x1-$x}] [expr {$y1-$y}]] x y x1 y1
 			}
+			
 			
 			set tags [dui::args::process_tags_and_var $pages dbutton {} 1 args 1]
 			set main_tag [lindex $tags 0]
@@ -7144,7 +7146,7 @@ msg "DUI ADD SHAPE outline_tags=[list ${main_tag}-out {*}[lrange $tags 1 end]]"
 			while { [info exists symbol$suffix] && [subst \$symbol$suffix] ne "" } {
 				dui add symbol $pages [subst \$xsymbol$suffix] [subst \$ysymbol$suffix] -text [subst \$symbol$suffix] \
 					-tags [subst \$symbol${suffix}_tags] -aspect_type "dbutton_symbol$suffix" \
-					-style $style {*}[subst \$symbol${suffix}_args]
+					-style $style -_abs_coords 1 {*}[subst \$symbol${suffix}_args]
 				set suffix [incr i]
 			}
 			
@@ -9002,10 +9004,10 @@ namespace eval ::dui::pages::dui_confirm_dialog {
 			-style dui_confirm_question -text "Are you sure?" 
 		
 		set data(n_buttons) 0
-		setup_buttons {Yes No}
+		setup_buttons {Yes No} $data(buttons_y)
 	}
 
-	proc setup_buttons { labels y } {
+	proc setup_buttons { labels {y 0.85} } {
 		variable data
 		variable widgets
 		set page [namespace tail [namespace current]]

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -4567,6 +4567,35 @@ namespace eval ::dui {
 			catch { delay_screen_saver }
 			
 			set page_to_hide [current]
+
+			set reload [dui::args::get_option -reload 0 1]
+			if { $current_page eq $page_to_show && ![string is true $reload] } {
+				#msg -NOTICE [namespace current] load "returning because current_page == $page_to_show"
+				return 
+			}
+			
+			set hide_ns [get_namespace $page_to_hide]
+			set show_ns [get_namespace $page_to_show]
+			
+			if { $page_to_hide eq "" } {
+				set hide_page_type ""
+			} else {
+				set hide_page_type [type $page_to_hide]
+			}
+			set show_page_type [type $page_to_show]
+			if { $show_page_type eq "dialog" && $hide_page_type eq "dialog" } {
+				msg -WARNING [namespace current] load: "only one dialog page can be visible, can't move from dialog '$page_to_hide' to dialog '$page_to_show'"
+				return
+			}
+			if { $hide_page_type eq "dialog" } {
+				# If the dialog loads a page that is different from the one that opened it, treat it like a normal page
+				# change (hide all items) instead of a dialog closing (hide only the dialog and reenable the background page)
+				if { $page_to_hide ne $previous_page } {
+					array set dialog_states {}
+					set return_callback {}
+					set hide_page_type "default"
+				}
+			}
 			
 			# run general load actions (same for all pages) in the global context. 
 			# If 1 or a string is returned, the loading process continues. 
@@ -4586,22 +4615,7 @@ namespace eval ::dui {
 					}
 				}
 			}
-
-			set reload [dui::args::get_option -reload 0 1]
-			if { $current_page eq $page_to_show && ![string is true $reload] } {
-				#msg -NOTICE [namespace current] load "returning because current_page == $page_to_show"
-				return 
-			}
 			
-			set hide_ns [get_namespace $page_to_hide]
-			set show_ns [get_namespace $page_to_show]
-			if { $page_to_hide eq "" } {
-				set hide_page_type ""
-			} else {
-				set hide_page_type [type $page_to_hide]
-			}
-			set show_page_type [type $page_to_show] 
-
 			msg [namespace current] load "$page_to_hide -> $page_to_show"
 			dui sound make page_change
 			
@@ -8874,4 +8888,3 @@ namespace eval ::dui::pages::dui_confirm_dialog {
 	}
 
 }
-	

--- a/de1plus/history_viewer.tcl
+++ b/de1plus/history_viewer.tcl
@@ -41,7 +41,7 @@ namespace eval ::history_viewer {
 	proc init {} {
 		pages::setup_default_styles
 		
-		dui page add history_viewer -namespace ::history_viewer::pages::history_viewer
+		dui page add history_viewer -namespace ::history_viewer::pages::history_viewer -type fpdialog
 	
 		vectors::init
 	}


### PR DESCRIPTION
This DUI update introduces "dialog" pages, as discussed on the [DUI dialogs](https://3.basecamp.com/3671212/buckets/7351439/messages/4137556613) thread in Diaspora.

`dui::page::add` now allows pages to have a type. Old/standard pages get the type "default" by default, and 2 new types of pages are introduced: "**dialog**" and "**fpdialog**".

- Pages of both "dialog" and "fpdialog" have DUI keeping a stack of open dialogs, so that control can be automatically returned to the page that opened the dialog. A return callback can be used to process the answer from the dialog.
- "fpdialog" are "Full Page Dialogs", and, like "default" pages, they occupy the whole screen
- "dialog" pages only occupy a part of the screen, and are open on top of the page that opens them. The page that opens them is not hidden but disabled. Current limitation is that only one page of type "dialog" can be visible on screen.

In addition, this update includes the following improvements:

- Percentage positions: Items added to pages can now define their coordinates and dimensions in percentage of the container page size, instead of absolute pixels. These are used when the values are greater than zero and smaller than one.

- Any page can now use a canvas shape as background, such as a rounded-corners rectangle (new option `-bg_shape` for `dui::page::add`.

- New generic page "dui_confirm_dialog"

- The history_viewer page now has type "fpdialog"

- New commands:
  - `dui::page::open_dialog` and `dui::page::close_dialog`
  - `dui::page::bbox`: Returns a list with the 4 bounding box (top-left and bottom-right) coordinates of the page.
  - `dui::page::moveto`: Moves a dialog page to new coordinates.
  - `dui::page::resize`: Resizes a dialog page.
  - `dui::page::recreate`: Recreates namespace pages, by deleting them from the canvas, then re-invoking their setup command. This allows, for example, fully modifying the aspect of pages at runtime (without an app restart) after changing display settings.
  - `dui::page::calc_x`, `dui::page::calc_y`, `dui::page::calc_width`, `dui::page::calc_height`: Transform relative and percentage page positions and sizes to absolute coordinates in the base 2560x1600 space.
  - `dui::add::shape`: A wrapper to create different types of shapes (same as used by dui::add::dbutton, such as rectangles, rounded-corners-rectangles, ovals) and add them to pages.
  - `dui::args::process_sizes`: Utility proc to process position and dimension arguments in box-type items
  
- Bug fixes:
  - Page `dui_item_selector` was not returning the correct item IDs where listbox elements had matching IDs and the listbox was filtered. Bug reported by JasonC.

This update is a big overhaul to how pages are loaded, shown and hidden. It should have no effect on existing pages, only adding possibilities for the new types of pages. **To test the new functionallity**, update to the latest repo version of the DYE and SDB plugins, enable DYE, modify some shot metadata and tap the "Cancel" button. A new DUI dialog will be shown (before, it was a Tk modal dialog window).