### PR TITLE
DUI & Metadata update

### DIFF
--- a/de1plus/app_metadata.tcl
+++ b/de1plus/app_metadata.tcl
@@ -172,7 +172,7 @@ proc init_app_metadata {} {
 		name_plural "Dose weights"
 		short_name "Dose" 
 		short_name_plural "Doses"
-		propagate 1
+		propagate 0
 		data_type number
 		min 0.0
 		max 30.0
@@ -196,7 +196,7 @@ proc init_app_metadata {} {
 		name_plural "Drink weights"
 		short_name "Yield" 
 		short_name_plural "Yields"
-		propagate 1
+		propagate 0
 		data_type number
 		min 0.0
 		max 500.0

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -775,6 +775,7 @@ namespace eval ::dui {
 			default.dbutton_label.font_size.insight_ok 19
 			
 			default.dclicker.fill {}
+			default.dclicker.disabledfill {}
 			default.dclicker_label.pos {0.5 0.5}
 			default.dclicker_label.font_size 18
 			default.dclicker_label.fill black
@@ -797,6 +798,7 @@ namespace eval ::dui {
 			default.multiline_entry.font_size 16
 			default.multiline_entry.width 15
 			default.multiline_entry.height 5
+			default.multiline_entry.wrap word
 
 			default.dcombobox.relief flat
 			default.dcombobox.bg white
@@ -906,6 +908,7 @@ namespace eval ::dui {
 			default.text.font_size 16
 			default.text.relief flat
 			default.text.highlightthickness 1
+			default.text.wrap word
 			
 			default.dbutton.shape.dne_clicker round 
 			default.dbutton.bwidth.dne_clicker 120 
@@ -932,7 +935,6 @@ namespace eval ::dui {
 			default.dbutton.shape.dui_confirm_button round
 			default.dbutton.bheight.dui_confirm_button 100
 			
-
 			default.dtext.font_size.menu_dlg_title +1
 			default.dtext.anchor.menu_dlg_title center
 			default.dtext.justify.menu_dlg_title center
@@ -7003,7 +7005,7 @@ namespace eval ::dui {
 				
 				set ids [dui::item::rounded_rectangle $rx $ry $rx1 $ry1 $radius $fill $disabledfill $tags]
 				set outline_tags [list ${main_tag}-out {*}[lrange $tags 1 end]]
-msg "DUI ADD SHAPE outline_tags=[list ${main_tag}-out {*}[lrange $tags 1 end]]"
+				
 				set ids [dui::item::rounded_rectangle_outline $rx $ry $rx1 $ry1 $radius $outline \
 					$disabledoutline $width $outline_tags]
 			} elseif { $shape eq "oval" } {

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -366,7 +366,7 @@ namespace eval ::dui {
 		# Create a special transparent full-page background for pages with type=dialog
 		$can create rect 0 0 [dui platform rescale_x $::dui::_base_screen_width] \
 			[dui platform rescale_y $::dui::_base_screen_height] -fill {} -width 0 -tags _dlg_bg -state hidden
-		$can bind _dlg_bg [dui::platform::button_press] {break}
+		$can bind _dlg_bg [dui::platform::button_press] {dui::page::dialog_background_press; break}
 		$can bind _dlg_bg <Double-Button-1> {break}
 		
 		# Launch setup methods of pages created with 'dui add page'
@@ -758,7 +758,7 @@ namespace eval ::dui {
 			default.dbutton_label1.justify center
 			default.dbutton_label1.fill "#7f879a"
 			default.dbutton_label1.activefill "#7f879a"
-			default.dbutton_label1.disabledfill black
+			default.dbutton_label1.disabledfill "#ccc"
 			
 			default.dbutton_symbol.pos {0.2 0.5}
 			default.dbutton_symbol.font_size 28
@@ -931,6 +931,42 @@ namespace eval ::dui {
 			
 			default.dbutton.shape.dui_confirm_button round
 			default.dbutton.bheight.dui_confirm_button 100
+			
+
+			default.dtext.font_size.menu_dlg_title +1
+			default.dtext.anchor.menu_dlg_title center
+			default.dtext.justify.menu_dlg_title center
+				
+			default.dbutton.shape.menu_dlg_close rect 
+			default.dbutton.fill.menu_dlg_close {} 
+			default.dbutton.symbol.menu_dlg_close times
+			default.dbutton_symbol.pos.menu_dlg_close {0.5 0.5}
+			default.dbutton_symbol.anchor.menu_dlg_close center
+			default.dbutton_symbol.justify.menu_dlg_close center
+			default.dbutton_symbol.fill.menu_dlg_close #3a3b3c
+				
+			default.dbutton.shape.menu_dlg_btn rect
+			default.dbutton.fill.menu_dlg_btn {}
+			default.dbutton.disabledfill.menu_dlg_btn {}
+			default.dbutton_label.pos.menu_dlg_btn {0.25 0.4} 
+			default.dbutton_label.anchor.menu_dlg_btn w
+			default.dbutton_label.fill.menu_dlg_btn #7f879a
+			default.dbutton_label.disabledfill.menu_dlg_btn #ddd
+				
+			default.dbutton_label1.pos.menu_dlg_btn {0.25 0.78} 
+			default.dbutton_label1.anchor.menu_dlg_btn w
+			default.dbutton_label1.fill.menu_dlg_btn #ccc
+			default.dbutton_label1.disabledfill.menu_dlg_btn #ddd
+			default.dbutton_label1.font_size.menu_dlg_btn -3
+				
+			default.dbutton_symbol.pos.menu_dlg_btn {0.15 0.5} 
+			default.dbutton_symbol.anchor.menu_dlg_btn center
+			default.dbutton_symbol.justify.menu_dlg_btn center
+			default.dbutton_symbol.fill.menu_dlg_btn #3a3b3c
+			default.dbutton_symbol.disabledfill.menu_dlg_btn #ddd
+				
+			default.line.fill.menu_dlg_sepline #ddd
+			default.line.width.menu_dlg_sepline 1 
 		}
 
 		# Named options:
@@ -5354,6 +5390,23 @@ namespace eval ::dui {
 			}
  
 			return $result
+		}
+		
+		# Run when the background page of a dialog is clicked.
+		# If the page has a close_dialog command, invoke it (useful for dialogs that need to always provide 
+		# data back to the invoking page), otherwise just call dui::page::close_dialog
+		proc dialog_background_press { } {
+			set dlg_page [current]
+			if { [type $dlg_page] ne "dialog" } {
+				return
+			}
+			
+			set ns [get_namespace $dlg_page]
+			if { [info procs ${ns}::close_dialog] ne "" } {
+				${ns}::close_dialog
+			} else {
+				dui::page::close_dialog
+			}
 		}
 		
 	}

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -5670,11 +5670,15 @@ namespace eval ::dui {
 			} else {
 				set state disabled
 			}
-						
+
 			foreach id [get $page_or_ids_or_widgets $tags] {
 				if { $do_current } {
 					if { [$can itemcget $id -state] ne "hidden" } {
 						$can itemconfigure $id -state $state
+						# Tk widgets need to be enabled/disabled directly, not through the canvas
+						if { [$can type $id] eq "window" } {
+							[$can itemcget $id -window] configure -state $state
+						}
 					}
 				}
 				if { $do_initial } {


### PR DESCRIPTION
This fixes a couple of minor bugs in DUI and metadata, plus adds some features needed in the new version of DYE:

- New commands dui::page::width, dui::page::height and dui::page::split_space
- Now DUI dialogs can be closed by tapping anywhere in the background page (except on Tk widgets, as these are always highest on the z-order stack)
- Change some default theme aspects for the new dialogs and "menu dialogs".
- Make dui::item::enable, dui::item::disable and dui::item::enable_or_disable work correctly on Tk widgets (previously they worked only with canvas items)
- Now only pages of type "dialog" are explicitly rethemed in dui::page::open_dialog, pages of type "fpdialog" are not, as this produced pages using aspects from mixed themes in some cases.
- App metadata: Make fields grinder_dose_weight and drink_weight not propagate (from last to next shot), for DYE to continue behaving as it has always done