### PR TITLE
Reset propagation of grinder_dose_weight

### DIFF
--- a/de1plus/app_metadata.tcl
+++ b/de1plus/app_metadata.tcl
@@ -172,7 +172,7 @@ proc init_app_metadata {} {
 		name_plural "Dose weights"
 		short_name "Dose" 
 		short_name_plural "Doses"
-		propagate 0
+		propagate 1
 		data_type number
 		min 0.0
 		max 30.0


### PR DESCRIPTION
Settings variable `grinder_dose_weight` is  defined again as a propagated field in metadata. This was changed in commit c5c3b12 and had the side effect of resetting the dose in the home page of the MimojaCafe skin every time a shot was started, so it has been reverted to `propagate=0`.