### PR TITLE
Replace ::mathfunc::max by our own version that works in older Androwish

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -6158,7 +6158,8 @@ namespace eval ::dui {
 			set nradius [llength $radius]
 			set radius [lreplicate 4 $radius]
 			lassign $radius radius1 radius2 radius3 radius4
-			set maxradius [tcl::mathfunc::max {*}$radius]
+			
+			set maxradius [::max {*}$radius]
 			
 			if { $radius1 > 0 } {
 				lappend ids [$can create oval $x0 $y0 [expr $x0 + $radius1] [expr $y0 + $radius1] -fill $colour -disabledfill $disabled \
@@ -6222,7 +6223,8 @@ namespace eval ::dui {
 			set nradius [llength $radius]
 			set radius [lreplicate 4 $radius]
 			lassign $radius radius1 radius2 radius3 radius4
-			set maxradius [tcl::mathfunc::max {*}$radius]
+			
+			set maxradius [::max {*}$radius]
 			
 			if { $width > 1 } {
 				# Adjustment to look better under Android, that uses dithering
@@ -8668,6 +8670,11 @@ proc value_or_default { var {default {}} } {
 	} else {
 		return $default
 	}
+}
+
+# tcl::mathfunc::max fails on older Androwish (TheLeydenJar), so we create our version, taken from https://wiki.tcl-lang.org/page/max # 
+proc max { args } {
+	lindex [lsort -real $args] end
 }
 
 ### FULL-PAGE EDITORS ################################################################################################


### PR DESCRIPTION
A recent commit adding multi-radius to DUI dbuttons (different radius per corner) was using `::tcl::mathfunc::max`, which was not available in the earlier versions of Androwish used in the very first tablets that came with the first DE1s. This is probably the reason that recent nightlies were crashing the app on startup seemingly at random: because it only affected users with older versions of Androwish.

So I've added our own `max` function and replaced calls to `::tcl::matchfunc::max` by calls to `::max`, and verified that it works both under "The Leyden Jar" and "Eppur si Muove" Androwish distributions.