### PR TITLE
Convert individual shots to v2 & profile basic to advanced with any array

### DIFF
--- a/de1plus/profile.tcl
+++ b/de1plus/profile.tcl
@@ -488,4 +488,30 @@ namespace eval ::profile {
             }
         }
     }
+    
+    # "sanitize" filename from profile title. Refactored from proc save_profile, so this is reusable in other parts
+    # of the code such as profiles importing from Visualizer.
+    proc filename_from_title { title } {
+        set fn $title
+        regsub -all {\s+} $fn _ fn 
+        regsub -all {\/+} $fn __ fn 
+        regsub -all {[\u0000-\u001f;:?<>(){}\[\]\|!@#$%^&*-\+=~`,.'"]+} $fn "" fn
+        return [string range $fn 0 59]
+    }
+    
+    # Ensure the profile type follows the latest app standard values. Refactored from proc select_profile, so this is reusable in other parts
+    # of the code such as profiles importing from Visualizer. 
+    proc fix_profile_type { profile_type } {
+        if { $profile_type eq "settings_2" || $profile_type eq "settings_profile_pressure" } {
+            set profile_type "settings_2a"
+        } elseif { $profile_type eq "settings_profile_flow" } {
+            set profile_type "settings_2b"
+        } elseif { $profile_type eq "settings_profile_advanced" || $profile_type eq "settings_2c2" } {
+            # old profile names that shouldn't exist any more, so upgrade them to the latest name
+            set profile_type "settings_2c"
+        }
+        
+        return $profile_type
+    }
+    
 }

--- a/de1plus/profile.tcl
+++ b/de1plus/profile.tcl
@@ -1,4 +1,4 @@
-package provide de1_profile 2.0
+Copackage provide de1_profile 2.0
 
 package require huddle
 package require json
@@ -8,17 +8,17 @@ namespace eval ::profile {
     variable current {}
     variable profile_version 2
 
-    proc pressure_to_advanced_list {} {
-        array set temp_advanced [settings_to_advanced_list]
+    proc pressure_to_advanced_list { {settingsvar ::settings} } {
+        array set temp_advanced [settings_to_advanced_list $settingsvar]
 
         set temp_advanced(advanced_shot) {}
         set temp_advanced(final_desired_shot_volume_advanced_count_start) 0
 
         if {[ifexists temp_advanced(espresso_temperature_steps_enabled)] == 1} {
-            set temp_bump_time_seconds $::settings(temp_bump_time_seconds)
+            set temp_bump_time_seconds [ifexists ${settingsvar}(temp_bump_time_seconds) 2]
             set first_frame_len $temp_bump_time_seconds
 
-            set second_frame_len [expr {$temp_advanced(preinfusion_time) - $temp_bump_time_seconds}]		
+            set second_frame_len [expr {$temp_advanced(preinfusion_time) - $temp_bump_time_seconds}]
             if {$second_frame_len < 0} { 
                 set second_frame_len 0
             }
@@ -191,17 +191,17 @@ namespace eval ::profile {
         return [array get temp_advanced]
     }
 
-    proc flow_to_advanced_list {} {
-        array set temp_advanced [settings_to_advanced_list]
+    proc flow_to_advanced_list { {settingsvar ::settings} } {
+        array set temp_advanced [settings_to_advanced_list $settingsvar]
 
         set temp_advanced(advanced_shot) {}
         set temp_advanced(final_desired_shot_volume_advanced_count_start) 0
 
         if {[ifexists temp_advanced(espresso_temperature_steps_enabled)] == 1} {
-            set temp_bump_time_seconds $::settings(temp_bump_time_seconds)
+            set temp_bump_time_seconds [ifexists ${settingsvar}(temp_bump_time_seconds) 2]
             set first_frame_len $temp_bump_time_seconds
 
-            set second_frame_len [expr {$temp_advanced(preinfusion_time) - $temp_bump_time_seconds}]		
+            set second_frame_len [expr {$temp_advanced(preinfusion_time) - $temp_bump_time_seconds}]
             if {$second_frame_len < 0} { 
                 set second_frame_len 0
             }
@@ -332,11 +332,11 @@ namespace eval ::profile {
         return [array get temp_advanced]
     }
 
-    proc settings_to_advanced_list {} {
+    proc settings_to_advanced_list { {settingsvar ::settings} } {
         array set temp_advanced {}
         foreach k [list profile_filename {*}[profile_vars]] {
-            if {[info exists ::settings($k)] == 1} {
-                set temp_advanced($k) $::settings($k)
+            if {[info exists ${settingsvar}($k)] == 1} {
+                set temp_advanced($k) [subst \$${settingsvar}($k)]
             }
         }
         return [array get temp_advanced]

--- a/de1plus/profile.tcl
+++ b/de1plus/profile.tcl
@@ -1,4 +1,4 @@
-Copackage provide de1_profile 2.0
+package provide de1_profile 2.0
 
 package require huddle
 package require json

--- a/de1plus/shot.tcl
+++ b/de1plus/shot.tcl
@@ -306,31 +306,11 @@ namespace eval ::shot {
         blt::vector create espresso_de1_explanation_chart_flow_2x espresso_de1_explanation_chart_flow_1_2x espresso_de1_explanation_chart_flow_2_2x espresso_de1_explanation_chart_flow_3_2x
         blt::vector create espresso_flow_delta_negative espresso_flow_delta_negative_2x
 
-
         foreach d $dirs {
             set fn "[homedir]/history/${d}"
-
             set fbasename [file rootname [file tail $d]]
-            set target_file "[homedir]/history_v2/${fbasename}.json"
+            convert_legacy_to_v2 $fn "[homedir]/history_v2" "${fbasename}.json" 0
 
-            if {[file exists $target_file]} {
-                continue
-            }
-            msg -INFO [namespace current] "Converting shot" $d "to version 2"
-
-            if {[catch {
-                set shot_file_contents [encoding convertfrom utf-8 [read_binary_file $fn]]
-                array set ::past_shot $shot_file_contents
-
-                array set ::settings $::past_shot(settings)
-                read_past_legacy_shot
-                ::profile::sync_from_legacy
-                set data [create]
-                write_file $target_file $data
-            } err] != 0} { 
-                msg -ERROR "Error while converting $d :" $err
-                borg toast [translate "Failure while converting. Please check logs"]
-            }
         }
 
         blt::vector destroy espresso_elapsed god_espresso_elapsed god_espresso_pressure steam_pressure steam_temperature steam_temperature100th steam_flow steam_elapsed espresso_pressure espresso_flow god_espresso_flow espresso_flow_weight god_espresso_flow_weight espresso_flow_weight_2x god_espresso_flow_weight_2x espresso_flow_2x god_espresso_flow_2x espresso_flow_delta espresso_pressure_delta espresso_temperature_mix espresso_temperature_basket god_espresso_temperature_basket espresso_state_change espresso_pressure_goal espresso_flow_goal espresso_flow_goal_2x espresso_temperature_goal espresso_weight espresso_weight_chartable espresso_resistance_weight espresso_resistance
@@ -342,4 +322,61 @@ namespace eval ::shot {
 
     }
 
+    proc convert_legacy_to_v2 { file {target_dir {}} {target_filename {}} {create_vectors 1} } {
+        if { [file exists $file] } {
+            set fn $file
+        } elseif { [file exists "[homedir]/history/$file"] } {
+            set fn "[homedir]/history/$file"
+        } else {
+            msg -ERROR [namespace current] "can't find file '$file' to convert"
+            return {}
+        }
+        
+        borg toast [translate "Converting shot file"]
+
+        if { [string is true $create_vectors] } {
+            blt::vector create espresso_elapsed god_espresso_elapsed god_espresso_pressure steam_pressure steam_temperature steam_temperature100th steam_flow steam_elapsed espresso_pressure espresso_flow god_espresso_flow espresso_flow_weight god_espresso_flow_weight espresso_flow_weight_2x god_espresso_flow_weight_2x espresso_flow_2x god_espresso_flow_2x espresso_flow_delta espresso_pressure_delta espresso_temperature_mix espresso_temperature_basket god_espresso_temperature_basket espresso_state_change espresso_pressure_goal espresso_flow_goal espresso_flow_goal_2x espresso_temperature_goal espresso_weight espresso_weight_chartable espresso_resistance_weight espresso_resistance
+            blt::vector create espresso_de1_explanation_chart_pressure espresso_de1_explanation_chart_flow espresso_de1_explanation_chart_elapsed espresso_de1_explanation_chart_elapsed_flow espresso_water_dispensed espresso_flow_weight_raw espresso_de1_explanation_chart_temperature  espresso_de1_explanation_chart_temperature_10 espresso_de1_explanation_chart_selected_step
+            blt::vector create espresso_de1_explanation_chart_flow_1 espresso_de1_explanation_chart_elapsed_flow_1 espresso_de1_explanation_chart_flow_2 espresso_de1_explanation_chart_elapsed_flow_2 espresso_de1_explanation_chart_flow_3 espresso_de1_explanation_chart_elapsed_flow_3
+            blt::vector create espresso_de1_explanation_chart_elapsed_1 espresso_de1_explanation_chart_elapsed_2 espresso_de1_explanation_chart_elapsed_3 espresso_de1_explanation_chart_pressure_1 espresso_de1_explanation_chart_pressure_2 espresso_de1_explanation_chart_pressure_3
+            blt::vector create espresso_de1_explanation_chart_flow_2x espresso_de1_explanation_chart_flow_1_2x espresso_de1_explanation_chart_flow_2_2x espresso_de1_explanation_chart_flow_3_2x
+            blt::vector create espresso_flow_delta_negative espresso_flow_delta_negative_2x
+        }
+        
+        if { $target_dir eq {} } {
+            set target_dir "[homedir]/history_v2"
+        }
+        if { $target_filename eq {} } {
+            set target_filename "[file rootname [file tail $fn]].json"
+        }
+        set target_file "${target_dir}/${target_filename}"
+
+        msg -INFO [namespace current] "Converting shot '$fn' to version 2, target '$target_file'"
+
+        if {[catch {
+            set shot_file_contents [encoding convertfrom utf-8 [read_binary_file $fn]]
+            array set ::past_shot $shot_file_contents
+
+            array set ::settings $::past_shot(settings)
+            read_past_legacy_shot
+            ::profile::sync_from_legacy
+            set data [create]
+            write_file $target_file $data
+        } err] != 0} { 
+            msg -ERROR "Error while converting $file :" $err
+            borg toast [translate "Failure while converting. Please check logs"]
+            set target_file {}
+        }
+
+        if { [string is true $create_vectors] } {
+            blt::vector destroy espresso_elapsed god_espresso_elapsed god_espresso_pressure steam_pressure steam_temperature steam_temperature100th steam_flow steam_elapsed espresso_pressure espresso_flow god_espresso_flow espresso_flow_weight god_espresso_flow_weight espresso_flow_weight_2x god_espresso_flow_weight_2x espresso_flow_2x god_espresso_flow_2x espresso_flow_delta espresso_pressure_delta espresso_temperature_mix espresso_temperature_basket god_espresso_temperature_basket espresso_state_change espresso_pressure_goal espresso_flow_goal espresso_flow_goal_2x espresso_temperature_goal espresso_weight espresso_weight_chartable espresso_resistance_weight espresso_resistance
+            blt::vector destroy espresso_de1_explanation_chart_pressure espresso_de1_explanation_chart_flow espresso_de1_explanation_chart_elapsed espresso_de1_explanation_chart_elapsed_flow espresso_water_dispensed espresso_flow_weight_raw espresso_de1_explanation_chart_temperature  espresso_de1_explanation_chart_temperature_10 espresso_de1_explanation_chart_selected_step
+            blt::vector destroy espresso_de1_explanation_chart_flow_1 espresso_de1_explanation_chart_elapsed_flow_1 espresso_de1_explanation_chart_flow_2 espresso_de1_explanation_chart_elapsed_flow_2 espresso_de1_explanation_chart_flow_3 espresso_de1_explanation_chart_elapsed_flow_3
+            blt::vector destroy espresso_de1_explanation_chart_elapsed_1 espresso_de1_explanation_chart_elapsed_2 espresso_de1_explanation_chart_elapsed_3 espresso_de1_explanation_chart_pressure_1 espresso_de1_explanation_chart_pressure_2 espresso_de1_explanation_chart_pressure_3
+            blt::vector destroy espresso_de1_explanation_chart_flow_2x espresso_de1_explanation_chart_flow_1_2x espresso_de1_explanation_chart_flow_2_2x espresso_de1_explanation_chart_flow_3_2x
+            blt::vector destroy espresso_flow_delta_negative espresso_flow_delta_negative_2x
+        }
+        
+        return $target_file
+    }
 }


### PR DESCRIPTION
This refactors a couple of shot & profile commands to work on arbitrary files instead of being bound to the global settings or all shots at once. This is in preparation of the forthcoming version of DYE that allows users to export past shot files and to view profiles from past shots.

- New command `shot::convert_legacy_to_v2` converts just one file. Code is taken from `shot::convert_all_legacy_to_v2`, which has been refactored to use the new command on each history file, to avoid code duplicity.

- `profile::pressure_to_advanced_list`, `profile::flow_to_advanced_list`, and `profile::settings_to_advanced_list` get an optional argument `settingsvar` that specifies the global variable they should use. This allows to make the conversion of basic (flow/pressure) profiles to advanced profiles not only on the global settings but on any arbitrary array having profile data (such as saved profiles or past shots read from history).