### PR TITLE
Profile read and textual

### DIFF
--- a/de1plus/profile.tcl
+++ b/de1plus/profile.tcl
@@ -513,5 +513,288 @@ namespace eval ::profile {
         
         return $profile_type
     }
+        
+    # Based on proc load_settings_vars, but only loads profile variables, and returns a list with the profile (which can be
+    # coerced to an array) instead of loading the profile into the global settings. The source file can also be a shot 
+    # file, and only the profile-related vars will be loaded from it, plus any variables given in list $extra_vars.
+    proc read_legacy { profile_path {extra_vars {}} } {
+        if { [file pathtype $profile_path] eq "relative" && [file dirname $profile_path] eq "." } {
+            set profile_path "[homedir]/profiles/[file tail $profile_path]"
+        }
+        if { [file extension $profile_path] eq "" } {
+            append profile_path ".tcl"
+        }
+        if { ![file exists $profile_path] } {
+            msg -WARNING [namespace current] load_profile: "profile file '$profile_path' not found"
+            return
+        }
+        
+        msg -INFO [namespace current] read_profile: "reading file '$profile_path'"
+        array set profile {}
     
+        # Set defaults in case they are not defined in the profile file 
+        set profile(final_desired_shot_volume_advanced_count_start) 0
+        set profile(settings_profile_type) "settings_2a"
+        set profile(beverage_type) "espresso"
+    
+        try {
+            array set arrfile [encoding convertfrom utf-8 [read_binary_file $profile_path]]
+        } on error err {
+            msg -WARNING [namespace current] read_profile: "error reading profile '$fn': $err"
+            return
+        }
+    
+        foreach k [concat [::profile_vars] $extra_vars] {
+            if { [info exists arrfile($k)] } {
+                set profile($k) $arrfile($k)
+            } elseif { ![info exists profile($k)] } {
+                set profile($k) {}
+            }
+        }
+        
+        set profile(settings_profile_type) [fix_profile_type $profile(settings_profile_type)]
+        
+        if { $profile(settings_profile_type) eq "settings_2c" && $profile(final_desired_shot_weight) ne "" &&
+                $profile(final_desired_shot_weight_advanced) eq "" } {
+            msg -NOTICE [namespace current] load_profile: "Using a default for final_desired_shot_weight_advanced " \
+                "from final_desired_shot_weight of $profile(final_desired_shot_weight)"
+            set profile(final_desired_shot_weight_advanced) $profile(final_desired_shot_weight)
+        }
+    
+        # pre-set the shot volume, to the shot weight, if importing an old shot definition that doesn't have a an end volume 
+        if { $profile(final_desired_shot_volume) eq "" } {
+            msg -NOTICE [namespace current] load_profile: "pre-set the shot volume, to the shot weight, if importing an old shot definition" \
+                "that doesn't have a an end volume"
+            set profile(final_desired_shot_volume) $profile(final_desired_shot_weight)
+        }
+    
+        if { $profile(advanced_shot) eq {} } {
+            # Dirty dirty trick, try to refactor pressure_to_advanced_list and flow_to_advanced_list to read an array instead
+            # of using a variable name
+            array set ::_prof_temp_shot [array get profile]
+            
+            # Ensure the profile's advanced_shot variable is always defined
+            switch $profile(settings_profile_type) \
+                settings_2a {
+                    array set temp_profile [pressure_to_advanced_list ::_prof_temp_shot]
+                    set profile(advanced_shot) $temp_profile(advanced_shot)
+                } settings_2b {
+                    array set temp_profile [flow_to_advanced_list ::_prof_temp_shot]
+                    set profile(advanced_shot) $temp_profile(advanced_shot)
+                }
+            
+            unset -nocomplain ::_prof_temp_shot
+        }
+        
+        return [array get profile]
+    }        
+    
+    # Returns a dictionary with a textual representation of the provided profile.
+    # The dictionary keys are the step numbers, with 0 corresponding to "global" profile metadata. Each step is also a dictionary.
+    # Each step variable is a list, where the first element is the translatable text string, and subsequent (optional) elements are the 
+    #    values to be replaced on the text string, matching codes "\1", "\2", etc in the main text string. Normally these values are
+    #    numbers, but all user-definable profile variables are coded like this, so things like "quickly/gradually" or "sensor/coffee"
+    #    also appear as replaceable strings.
+    #
+    # Step 0 dictionary can have keys 'title', 'type', 'nsteps', 'notes', 'preheat', 'limiter' and 'stop_at'. 
+    # Step 1 to <nsteps> is each a dictionary which can have keys 'name', 'type', 'track', 'temp', 'flow_or_pressure', 'max', and 'exit_if'
+    #
+    # If a step doesn't have values for an element (e.g. a step doesn't define any "maximum" values), that key is NOT created.    
+    proc legacy_to_textual { list_profile } {
+        array set profile $list_profile
+        set pdict [dict create]
+    
+        # Step 0 contains profile "globals"
+        dict set pdict 0 title [list $profile(profile_title)] 
+        
+        set bev_type [value_or_default $profile(beverage_type) "espresso"]
+        if { $bev_type == 0 } {
+            set bev_type "espresso"
+        }
+        switch [fix_profile_type $profile(settings_profile_type)] \
+            settings_2a {
+                dict set pdict 0 type [list "Pressure $bev_type profile"]
+            } settings_2b {
+                dict set pdict 0 type [list "Flow $bev_type profile"]
+            } settings_2c {
+                dict set pdict 0 type [list "Advanced $bev_type profile"]
+            } default {
+                dict set pdict 0 type [list "Unknown $bev_type profile type"]
+            }
+    
+        if { $profile(tank_desired_water_temperature) > 0 } {
+            dict set pdict 0 preheat [list "Preheat water tank at \\1 ºC" [round_to_one_digits $profile(tank_desired_water_temperature)]]
+        }
+    
+        # Limiters
+        set ndef [expr {($profile(maximum_pressure_range_advanced)>0)+($profile(maximum_flow_range_advanced)>0)}]
+        if { $ndef == 1 } {
+            if { $profile(maximum_flow_range_advanced) > 0 } {
+                dict set pdict 0 limiter [list "Limiter range of action: \\1 mL/s" [round_to_one_digits $profile(maximum_flow_range_advanced)]]
+            } elseif { $profile(maximum_pressure_range_advanced) > 0 } {
+                dict set pdict 0 limiter [list "Limiter range of action: \\1 bar" [round_to_one_digits $profile(maximum_pressure_range_advanced)]]
+            }
+        } elseif { $ndef == 2 } {
+            dict set pdict 0 limiter [list "Limiter ranges of action: \\1 mL/s and \\2 bar" \
+                [round_to_one_digits $profile(maximum_flow_range_advanced)] [round_to_one_digits $profile(maximum_pressure_range_advanced)]]
+        }
+    
+        # Ending criteria
+        set txt ""
+        set items {}    
+        set n_max [expr {($profile(final_desired_shot_volume)>0)+($profile(final_desired_shot_weight)>0)}]
+        if { $n_max > 0 } {
+            if { $n_max == 1 } {
+                if { $profile(final_desired_shot_volume) > 0 } {
+                    set txt "Stop at \\1 mL volume"
+                    lappend items [round_to_one_digits $profile(final_desired_shot_volume)]
+                } elseif { $profile(final_desired_shot_weight) > 0 } {
+                    set txt "Stop at \\1 g weight"
+                    lappend items [round_to_one_digits $profile(final_desired_shot_weight)]
+                }
+            } elseif { $n_max == 2 } {
+                set txt "Stop at \\1 mL volume or \\2 g weight"
+                lappend items [round_to_one_digits $profile(final_desired_shot_volume)] [round_to_one_digits $profile(final_desired_shot_weight)]
+            }
+            dict set pdict 0 stop_at [list $txt {*}$items]
+        }
+        
+        dict set pdict 0 notes [list $profile(profile_notes)]
+        
+        # Profile steps
+        set stepn 1
+        set prev_temp 0.0
+        set prev_sensor ""
+        set prev_pressure_or_flow 0.0 
+        set prev_pump ""
+        set time_adjust 0.0
+        
+        foreach stepl $profile(advanced_shot) {
+            array set step $stepl
+            # Ignore the extra 3-second steps added by conversion of basic (flow/pressure) to advanced profile, as they are 
+            # not in the GUI and would only confuse users, and undo the 3-seconds adjustments to match what's defined in the GUI 
+            if { $profile(espresso_hold_time) > 0 && $step(seconds) == 3 && $step(volume) == 0 && $step(exit_if) == 0 } {
+                set time_adjust 3.0
+                continue
+            }
+            
+            dict set pdict $stepn name [list $step(name)]
+    
+            if { $stepn > 1 && $profile(final_desired_shot_volume_advanced_count_start) == $stepn-1 } {
+                dict set pdict $stepn track [list "Start tracking water volume"]
+            }
+        
+            # Temperature
+            if { $stepn == 1 || $prev_sensor ne $step(sensor) } {
+                dict set pdict $stepn temp [list "Set \\1 temperature to \\2 ºC" $step(sensor) [round_to_one_digits $step(temperature)]]
+            } elseif { $prev_temp == $step(temperature) } {
+                dict set pdict $stepn temp [list "Maintain \\1 temperature at \\2 ºC" $step(sensor) [round_to_one_digits $step(temperature)]]
+            } elseif { $prev_temp < $step(temperature) } {
+                dict set pdict $stepn temp [list "Increase \\1 temperature to \\2 ºC" $step(sensor) [round_to_one_digits $step(temperature)]]
+            } else {
+                dict set pdict $stepn temp [list "Decrease \\1 temperature to \\2 ºC" $step(sensor) [round_to_one_digits $step(temperature)]]
+            }
+            
+            # Flow or pressure
+            ifexists step(max_flow_or_pressure) 0
+            if { $step(transition) eq "smooth" } {
+                set step(transition) "gradually"
+            } elseif { $step(transition) eq "fast" } {
+                set step(transition) "quickly"
+            }
+            
+            set txt ""
+            set items {}
+            if { $step(pump) eq "flow" } {
+                set txt "Pour \\1 at a rate of \\2 mL/s"
+                lappend items $step(transition) [round_to_one_digits $step(flow)]
+                
+                if { $step(max_flow_or_pressure) > 0 } {
+                    append txt " with a pressure limit of \\3 bar"
+                    lappend items [round_to_one_digits $step(max_flow_or_pressure)]
+                }
+            } elseif { $step(pump) eq "pressure" } {
+                if { $stepn == 1 || ($prev_pump ne "pressure" && $step(pressure) > 0) || \
+                        ($stepn > 1 && $prev_pump eq "pressure" && $step(pressure) > $prev_pressure_or_flow ) } {
+                    set txt  "Pressurize \\1 to \\2 bar"
+                    lappend items $step(transition) [round_to_one_digits $step(pressure)]
+                } elseif { $step(pressure) == 0 } {
+                    set txt  "Depressurize \\1 to \\2 bar"
+                    lappend items $step(transition) [round_to_one_digits $step(pressure)]
+                } else {
+                    set txt  "Decrease pressure \\1 to \\2 bar"
+                    lappend items $step(transition) [round_to_one_digits $step(pressure)]
+                }
+                
+                if { $step(max_flow_or_pressure) > 0 } {
+                    append txt " with a flow limit of \\3 mL/s"
+                    lappend items [round_to_one_digits $step(max_flow_or_pressure)]
+                }                
+            }
+            
+            dict set pdict $stepn flow_or_pressure [list $txt {*}$items]
+            
+            # Maximum
+            if { $time_adjust != 0 } {
+                set step(seconds) [expr {$step(seconds)+$time_adjust}] 
+            }
+            ifexists step(weight) 0
+            
+            set txt ""
+            set items {}
+            set n_max [expr {($step(seconds)>0)+($step(volume)>0)+($step(weight)>0)}]
+            if { $n_max > 0 } {
+                if { $n_max == 1 } {
+                    set txt "For a maximum of \\1 \\2"
+                } elseif { $n_max == 2 } {
+                    set txt "For a maximum of \\1 \\2 or \\3 \\4"
+                } elseif { $n_max == 3 } {
+                    set txt "For a maximum of \\1 \\2 ,\\3 \\4 or \\5 \\6"
+                }
+            
+                if { $step(seconds) > 0 } {
+                    lappend items [round_to_one_digits $step(seconds)] "sec"
+                    incr n_used
+                }
+                if { $step(volume) > 0 } {
+                    lappend items [round_to_one_digits $step(volume)] "mL"
+                }
+                if { $step(weight) > 0 } {
+                    lappend items [round_to_one_digits $step(weight)] "g"
+                }
+                
+                dict set pdict $stepn max [list $txt {*}$items]
+            }
+            
+            # Move on if
+            if { $step(exit_if) } {
+                if { $step(exit_flow_over) > 0 } {
+                    dict set pdict $stepn exit_if "Move on if flow is \\1 \\2 mL/s" "over" [round_to_one_digits $step(exit_flow_over)]
+                } elseif { $step(exit_flow_under) > 0 } {
+                    dict set pdict $stepn exit_if "Move on if flow is \\1 \\2 mL/s" "under" [round_to_one_digits $step(exit_flow_under)]
+                } elseif { $step(exit_pressure_over) > 0 } {
+                    dict set pdict $stepn exit_if "Move on if pressure is \\1 \\2 bar" "over" [round_to_one_digits $step(exit_pressure_over)]
+                } elseif { $step(exit_pressure_under) > 0 } {
+                    dict set pdict $stepn exit_if "Move on if pressure is \\1 \\2 mL/s" "under" [round_to_one_digits $step(exit_pressure_under)]
+                }
+            }
+            
+            # Next step preparation
+            set time_adjust 0.0
+            set prev_sensor $step(sensor)
+            set prev_temp $step(temperature)
+            set prev_pump $step(pump)
+            if { $prev_pump eq "flow" } {
+                set prev_pressure_or_flow $step(flow)
+            } else {
+                set prev_pressure_or_flow $step(pressure)
+            }
+            incr stepn
+        }
+    
+        dict set pdict 0 nsteps [expr {$stepn-1}]
+        
+        return $pdict
+    }
+
 }

--- a/de1plus/profile.tcl
+++ b/de1plus/profile.tcl
@@ -600,8 +600,8 @@ namespace eval ::profile {
     # Step 1 to <nsteps> is each a dictionary which can have keys 'name', 'type', 'track', 'temp', 'flow_or_pressure', 'max', and 'exit_if'
     #
     # If a step doesn't have values for an element (e.g. a step doesn't define any "maximum" values), that key is NOT created.    
-    proc legacy_to_textual { list_profile } {
-        array set profile $list_profile
+    proc legacy_to_textual { profile_list } {
+        array set profile $profile_list
         set pdict [dict create]
     
         # Step 0 contains profile "globals"

--- a/de1plus/profile.tcl
+++ b/de1plus/profile.tcl
@@ -35,7 +35,7 @@ namespace eval ::profile {
 
         if {$first_frame_len > 0} {
             set preinfusion [list \
-                name [translate "preinfusion temp boost"] \
+                name "preinfusion temp boost" \
                 temperature $temp_advanced(espresso_temperature_0) \
                 sensor "coffee" \
                 pump "flow" \
@@ -57,7 +57,7 @@ namespace eval ::profile {
 
         if {$second_frame_len > 0} {
             set preinfusion2 [list \
-                name [translate "preinfusion"] \
+                name "preinfusion" \
                 temperature $temp_advanced(espresso_temperature_1) \
                 sensor "coffee" \
                 pump "flow" \
@@ -81,7 +81,7 @@ namespace eval ::profile {
             if {$temp_advanced(espresso_hold_time) > 3} {
                 # Second rise step without limiter
                 set pressure_up [list \
-                    name [translate "forced rise without limit"] \
+                    name "forced rise without limit" \
                     temperature $temp_advanced(espresso_temperature_2) \
                     sensor "coffee" \
                     pump "pressure" \
@@ -99,7 +99,7 @@ namespace eval ::profile {
                 set temp_advanced(espresso_hold_time) [expr $temp_advanced(espresso_hold_time) - 3]
             }
             set hold [list \
-                name [translate "rise and hold"] \
+                name "rise and hold" \
                 temperature $temp_advanced(espresso_temperature_2) \
                 sensor "coffee" \
                 pump "pressure" \
@@ -125,7 +125,7 @@ namespace eval ::profile {
             if {$temp_advanced(espresso_hold_time) < 3 && $temp_advanced(espresso_decline_time) > 3} {
                 # Second rise step without limiter
                 set pressure_up [list \
-                    name [translate "forced rise without limit"] \
+                    name "forced rise without limit" \
                     temperature $temp_advanced(espresso_temperature_3) \
                     sensor "coffee" \
                     pump "pressure" \
@@ -144,7 +144,7 @@ namespace eval ::profile {
             }
 
             set decline [list \
-                name [translate "decline"] \
+                name "decline" \
                 temperature $temp_advanced(espresso_temperature_3) \
                 sensor "coffee" \
                 pump "pressure" \
@@ -167,7 +167,7 @@ namespace eval ::profile {
 
         if {[llength $temp_advanced(advanced_shot)] == 0} {
                 set empty [list \
-                name [translate "empty"] \
+                name "empty" \
                 temperature 90 \
                 sensor "coffee" \
                 pump "flow" \
@@ -220,7 +220,7 @@ namespace eval ::profile {
 
         if {$first_frame_len > 0} {
             set preinfusion [list \
-                name [translate "preinfusion boost"] \
+                name "preinfusion boost" \
                 temperature $temp_advanced(espresso_temperature_0) \
                 sensor "coffee" \
                 pump "flow" \
@@ -242,7 +242,7 @@ namespace eval ::profile {
 
         if {$second_frame_len > 0} {
             set preinfusion2 [list \
-                name [translate "preinfusion"] \
+                name "preinfusion" \
                 temperature $temp_advanced(espresso_temperature_1) \
                 sensor "coffee" \
                 pump "flow" \
@@ -264,7 +264,7 @@ namespace eval ::profile {
 
         if {$temp_advanced(espresso_hold_time) > 0} {
             set hold [list \
-                name [translate "hold"] \
+                name "hold" \
                 temperature $temp_advanced(espresso_temperature_2) \
                 sensor "coffee" \
                 pump "flow" \
@@ -287,7 +287,7 @@ namespace eval ::profile {
 
         if {$temp_advanced(espresso_hold_time) > 0} {
             set decline [list \
-                name [translate "decline"] \
+                name "decline" \
                 temperature $temp_advanced(espresso_temperature_3) \
                 sensor "coffee" \
                 pump "flow" \
@@ -310,7 +310,7 @@ namespace eval ::profile {
 
         if {[llength $temp_advanced(advanced_shot)] == 0} {
                 set empty [list \
-                name [translate "empty"] \
+                name "empty" \
                 temperature 90 \
                 sensor "coffee" \
                 pump "flow" \

--- a/de1plus/profile.tcl
+++ b/de1plus/profile.tcl
@@ -768,13 +768,13 @@ namespace eval ::profile {
             
             # Move on if
             if { $step(exit_if) } {
-                if { $step(exit_flow_over) > 0 } {
+                if { $step(exit_type) eq "flow_over" } {
                     dict set pdict $stepn exit_if "Move on if flow is \\1 \\2 mL/s" "over" [round_to_one_digits $step(exit_flow_over)]
-                } elseif { $step(exit_flow_under) > 0 } {
+                } elseif { $step(exit_type) eq "flow_under" } {
                     dict set pdict $stepn exit_if "Move on if flow is \\1 \\2 mL/s" "under" [round_to_one_digits $step(exit_flow_under)]
-                } elseif { $step(exit_pressure_over) > 0 } {
+                } elseif { $step(exit_type) eq "pressure_over" } {
                     dict set pdict $stepn exit_if "Move on if pressure is \\1 \\2 bar" "over" [round_to_one_digits $step(exit_pressure_over)]
-                } elseif { $step(exit_pressure_under) > 0 } {
+                } elseif { $step(exit_type) eq "pressure_under" } {
                     dict set pdict $stepn exit_if "Move on if pressure is \\1 \\2 mL/s" "under" [round_to_one_digits $step(exit_pressure_under)]
                 }
             }


### PR DESCRIPTION
This adds new features to the `::profile` namespace and modifies a few things to make them more generic, so they can be used in the next version of the DYE Profile Viewer:

# New
- New command `profile::read_legacy`, reads a legacy (.tcl) profile into an array. This is needed because the standard profile loading command is `load_settings_var`, which loads directly into the global `$::settings` variable, whereas the new command will restrict the read variables to those from profiles, and return the result as a list that can be set to an array.
- New command `profile::legacy_to_textual` transforms a legacy (.tcl) profile into a dictionary with a human-readable textual representation of the profile. This has been refactored from code in the DYE plugin so it can be easily reused by all skin & plugin programmers.

# Changed
- The 3 commands `profile::pressure_to_advanced_list`, `profile::flow_to_advanced_list`  and `profile::settings_to_advanced_list` now use `upvar` on its first optional argument, and thus can be applied to any list, including local variables in the invoking proc. Still default to use `::settings` if  they receive no argument, so totally backwards-compatible. 
- Step names when generating `advanced_shot` from basic flow or pressure profiles are not translated anymore. Translation should be done only in the GUI, and this could produce translated steps in the profile file, which if are ever translated into a third language because the user changed his app language, would never be translated back.
