### PR TITLE
Legacy profile management commands

### DIFF
--- a/de1plus/profile.tcl
+++ b/de1plus/profile.tcl
@@ -520,6 +520,32 @@ namespace eval ::profile {
         return $profile_type
     }
         
+	proc profile_type_text { profile_type {beverage_type {}} } {
+		switch [fix_profile_type $profile_type] \
+		settings_2a {
+			set type "Pressure"
+		} settings_2b {
+			set type "Flow"
+		} settings_2c {
+			set type "Advanced"
+		} default {
+			set type "Unknown"
+		}
+		
+		switch [lindex $beverage_type 0] \
+			pourover {
+				set beverage_type "pour-over "
+			} tea_portafilter {
+				set beverage_type "tea "
+			} {} {
+				set beverage_type ""
+			} default {
+				set beverage_type "$beverage_type "
+			}
+		
+		return "${type} ${beverage_type}profile"
+	}
+	
     # Based on proc load_settings_vars, but only loads profile variables, and returns a list with the profile (which can be
     # coerced to an array) instead of loading the profile into the global settings. The source file can also be a shot 
     # file, and only the profile-related vars will be loaded from it, plus any variables given in list $extra_vars.

--- a/de1plus/profile.tcl
+++ b/de1plus/profile.tcl
@@ -532,7 +532,7 @@ namespace eval ::profile {
             set type "Unknown"
         }
         
-        switch [lindex $beverage_type 0] \
+        switch [string trim [lindex $beverage_type 0]] \
             pourover {
                 set beverage_type "pour-over "
             } tea_portafilter {
@@ -559,8 +559,12 @@ namespace eval ::profile {
             append filename $ext
         }
         
-        if { [file pathtype $filename] eq "relative" && [file dirname $filename] eq "." } {
-            set filepath "[homedir]/profiles/[file tail $filename]"
+        if { [file pathtype $filename] eq "relative" } {
+            if { [file dirname $filename] eq "." } {
+                set filepath "[homedir]/${folder}/[file tail $filename]"
+            } else {
+                set filepath "[homedir]/$filename"
+            }
         } else {
             set filepath $filename
         }


### PR DESCRIPTION
New and modified commands in the `::profile` namespace, continuing with the objective of providing a set of reusable commands to manage profiles that work on input and output data different of the `settings` global variable. All of this is needed for the forthcoming version of DYE.

- New command `profile::profile_type_text` returns an english textual description of the profile type that includes both `settings_profile_type` and `beverage_type` in one.
- New command `profile::find_file` returns the full path for an existing profile filename (both legacy and v2)
- New command `profile::modify_legacy` to easily modify parts of legacy profile files.
- New command `profile::import_legacy`, taken from DYE, handles importing legacy profiles from sources such as history shots or Visualizer downloads.

Also, the existing command `profile::read_legacy` is now more versatile, allowing different types of input data.