### PR TITLE
Fix profile functions & DYE update

### DIFF
--- a/de1plus/profile.tcl
+++ b/de1plus/profile.tcl
@@ -602,6 +602,8 @@ namespace eval ::profile {
         
             if { $src_type eq "shot_file" } {
                 array set src_array $src_array(settings)
+            } elseif { $src_type eq "profile_file" } {
+                set src_array(profile_filename) [file rootname [file tail $filepath]]
             }
         } elseif { $src_type eq "list" } {
             array set src_array [$src]
@@ -682,7 +684,7 @@ namespace eval ::profile {
         foreach var [array names arrchanges] {
             if { $var in [profile_vars] } {
                 if { ![info exists profile($var)] || $profile($var) ne $arrchanges($var) } {
-                    msg -INFO [namespace current] modify_legacy: "Profile '$filename' variable '$var' changes from '$profile($var)' to '$arrchanges($var)'"
+                    msg -INFO [namespace current] modify_legacy: "Profile '$filename' variable '$var' changes from '[value_or_default profile($var) {}]' to '$arrchanges($var)'"
                     set profile($var) $arrchanges($var)
                     set some_change 1
                 } else {


### PR DESCRIPTION
Fixes in profile procs:
- Set variable `profile_filename` in read_legacy when src_type='profile_file'
- Fix bug in a log message in `modify_legacy` when the var being defined was undefined in the original profile file. This produced a runtime error when trying to modify the beverage type in the DYE Profile Viewer and it was not defined at all in the profile file.

Minor changes in DYE profile tools buttons and workflow:

- Profile Viewer and Profile Selector now each get its own icon in buttons.
- Added button to launch the Profile Selector also in basic profiles editors (only appeared in advanced)
- Removed the Profile Selector button that appeared wrongly in page `settings_2c2`
- New button on the Profile Selector to preview the selected profile in the Profile Viewer.
