### PR TITLE
Always overwrite basic profiles' advanced_shot in profile::read_legacy

### DIFF
--- a/de1plus/profile.tcl
+++ b/de1plus/profile.tcl
@@ -650,17 +650,15 @@ namespace eval ::profile {
             set profile(final_desired_shot_volume) $profile(final_desired_shot_weight)
         }
     
-        if { $profile(advanced_shot) eq {} } {
-            # Ensure the profile's advanced_shot variable is always defined
-            switch $profile(settings_profile_type) \
-                settings_2a {
-                    array set temp_profile [pressure_to_advanced_list profile]
-                    set profile(advanced_shot) $temp_profile(advanced_shot)
-                } settings_2b {
-                    array set temp_profile [flow_to_advanced_list profile]
-                    set profile(advanced_shot) $temp_profile(advanced_shot)
-                }
-        }
+        # Ensure the profile's advanced_shot variable is always defined. Overwrite it if already defined.
+        switch $profile(settings_profile_type) \
+            settings_2a {
+                array set temp_profile [pressure_to_advanced_list profile]
+                set profile(advanced_shot) $temp_profile(advanced_shot)
+            } settings_2b {
+                array set temp_profile [flow_to_advanced_list profile]
+                set profile(advanced_shot) $temp_profile(advanced_shot)
+            }
         
         return [array get profile]
     }


### PR DESCRIPTION
`profile::read_legacy` now always overwrites the `advanced_shot` variable of basic profiles if it is already defined in the file, to ensure its definition matches the basic profile variables in the GUI. 

This will avoid errors like the one in profile `Best overall pressure profile.tcl`, whose `advanced_shot` in the repo profile as of 2021-12-05 had nothing to do with the basic profile definition, as [reported by Richard Steeper](https://3.basecamp.com/3671212/buckets/7351439/messages/4141407262#__recording_4416261147).