### PR TITLE
legacy_to_textual don't show "Per-step temps" text in non-basic profiles

### DIFF
--- a/de1plus/profile.tcl
+++ b/de1plus/profile.tcl
@@ -833,7 +833,7 @@ namespace eval ::profile {
 
         # Temperature steps
         set temp_steps [string is true [value_or_default profile(espresso_temperature_steps_enabled) 0]]
-        if { $temp_steps } {
+        if { $is_basic_profile & $temp_steps } {
             dict set pdict 0 temp_steps [list "Per-step temperatures enabled"]
         }
         


### PR DESCRIPTION
The textual representation of profiles produced by `profile::legacy_to_textual` now does _not_ show the "Per-step temperatures enabled" message if the profile is advanced. Solves the problem reported by Richard Steeper.