### PR TITLE
Fix typo "ifexist"

### DIFF
--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -1492,7 +1492,7 @@ proc de1_ble_handler { event data } {
 							append_to_peripheral_list $address $::settings(scale_bluetooth_name) "ble" "scale" "acaiapyxis"
 							msg -INFO "Pyxis scale showed up"
 
-							if {[ifexist ::sinstance($::de1(suuid_acaia_pyxis))] == {}} {
+							if {[ifexists ::sinstance($::de1(suuid_acaia_pyxis))] == {}} {
 								msg -NOTICE "fake connction to acaia scale. Closing handle again"
 								ble close $handle
 								ble_connect_to_scale


### PR DESCRIPTION
This PR fixes `Error: invalid command name "ifexist"` error message.

![Screenshot_20220114-124410](https://user-images.githubusercontent.com/151614/149505720-68897eea-5efa-48e8-bdb7-3384a4be23a9.png)

This issue was also reported in Dicent forum.
https://3.basecamp.com/3671212/buckets/7351439/messages/4347747948#__recording_4521693300