### PR TITLE
introduce option to enable scales timer only for Espresso

### DIFF
--- a/de1plus/device_scale.tcl
+++ b/de1plus/device_scale.tcl
@@ -1366,8 +1366,9 @@ namespace eval ::device::scale::callbacks {
 
 		set this_state [dict get $event_dict this_state]
 
-		if { [::de1::state::is_flow_state $this_state] \
-			     && $::device::scale::run_timer } {
+		if { ([::de1::state::is_flow_state $this_state] \
+			     && $::device::scale::run_timer) && \
+				 ($::settings(scale_timer_espresso_only) == 0 || $this_state == "Espresso") } {
 
 			scale_timer_reset
 		}
@@ -1446,6 +1447,9 @@ namespace eval ::device::scale::callbacks {
 	proc on_flow_change_manage_timer {event_dict} {
 
 		if { ! $::device::scale::run_timer } { return }
+
+		if { $::settings(scale_timer_espresso_only) == 1 && \
+			     [dict get $event_dict this_state] != "Espresso" }  { return }
 
 		if { [::de1::state::flow_phase \
 			      [dict get $event_dict this_state] \

--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -432,6 +432,7 @@ array set ::settings {
 	create_legacy_shotfiles 0
 
 	show_scale_notifications 1
+	scale_timer_espresso_only 0
 }
 
 # default de1plus skin


### PR DESCRIPTION
As discussed with @decentjohn at Diaspora [1] this PR adds an option to let scale timers only run, if an Espresso is made. So the duration of the last Espresso is always shown at the scale display, not matter if one flushed or steamed afterwards.

[1] https://3.basecamp.com/3671212/buckets/7351439/messages/4509014809