### PR TITLE
Updated logs to use v2

### DIFF
--- a/de1plus/utils.tcl
+++ b/de1plus/utils.tcl
@@ -574,7 +574,7 @@ proc check_battery_low {brightness_to_use} {
     if {$percent < $::settings(battery_very_low_trigger_v2)} {
         if {$current_brightness > $::settings(battery_very_low_brightness)} {
             get_set_tablet_brightness $::settings(battery_very_low_brightness)
-            msg -WARNING "Battery is very low ($percent < $::settings(battery_very_low_trigger)) so lowering screen to $::settings(battery_very_low_brightness)"
+            msg -WARNING "Battery is very low ($percent < $::settings(battery_very_low_trigger_v2)) so lowering screen to $::settings(battery_very_low_brightness)"
         }
         if {$brightness_to_use > $::settings(battery_very_low_brightness)} {
             return $::settings(battery_very_low_brightness)
@@ -582,7 +582,7 @@ proc check_battery_low {brightness_to_use} {
     } elseif {$percent < $::settings(battery_low_trigger_v2)} {
         if {$current_brightness > $::settings(battery_low_brightness)} {
             get_set_tablet_brightness $::settings(battery_low_brightness)
-            msg -WARNING "Battery is low ($percent < $::settings(battery_low_trigger)) so lowering screen to $::settings(battery_low_brightness)"
+            msg -WARNING "Battery is low ($percent < $::settings(battery_low_trigger_v2)) so lowering screen to $::settings(battery_low_brightness)"
         }
         if {$brightness_to_use > $::settings(battery_low_brightness)} {
             return $::settings(battery_low_brightness)
@@ -591,7 +591,7 @@ proc check_battery_low {brightness_to_use} {
     } elseif {$percent < $::settings(battery_medium_trigger_v2)} {
         if {$current_brightness > $::settings(battery_medium_brightness)} {
             get_set_tablet_brightness $::settings(battery_medium_brightness)
-            msg -NOTICE "Battery is medium ($percent < $::settings(battery_medium_trigger)) so lowering screen to $::settings(battery_medium_brightness)"
+            msg -NOTICE "Battery is medium ($percent < $::settings(battery_medium_trigger_v2)) so lowering screen to $::settings(battery_medium_brightness)"
         }
         if {$brightness_to_use > $::settings(battery_medium_brightness)} {
             return $::settings(battery_medium_brightness)


### PR DESCRIPTION
Experienced this when battery was low. Updated the logs to use v2 to prevent crash:

Untrapped error running de1_ui_startup with result: can't read "::settings(battery_very_low_trigger)": no such element in array
2022-08-29 07:06:50.580 CRITICAL: -code 1 -level 0 -errorstack {INNER loadArrayStk CALL {check_battery_low 70} CALL {display_brightness 70} CALL {::page_onload {} off} UP 5 CALL {::dui::page::load off} CALL {page_display_change splash off} CALL run_de1_app CALL ui_startup CALL de1_ui_startup} -errorcode {TCL READ VARNAME} -errorinfo {can't read "::settings(battery_very_low_trigger)": no such element in array
2022-08-29 07:06:50.580 CRITICAL:     while executing
2022-08-29 07:06:50.580 CRITICAL: "msg -WARNING "Battery is very low ($percent < $::settings(battery_very_low_trigger)) so lowering screen to $::settings(battery_very_low_brightness)""
2022-08-29 07:06:50.580 CRITICAL:     (procedure "check_battery_low" line 20)
2022-08-29 07:06:50.580 CRITICAL:     invoked from within
2022-08-29 07:06:50.580 CRITICAL: "check_battery_low $percentage"
2022-08-29 07:06:50.580 CRITICAL:     (procedure "display_brightness" line 2)
2022-08-29 07:06:50.580 CRITICAL:     invoked from within
2022-08-29 07:06:50.580 CRITICAL: "display_brightness $::settings(app_brightness)"
2022-08-29 07:06:50.580 CRITICAL:     (procedure "::page_onload" line 3)
2022-08-29 07:06:50.580 CRITICAL:     invoked from within
2022-08-29 07:06:50.580 CRITICAL: "::page_onload {} off"
2022-08-29 07:06:50.580 CRITICAL:     ("uplevel" body line 1)
2022-08-29 07:06:50.580 CRITICAL:     invoked from within
2022-08-29 07:06:50.580 CRITICAL: "uplevel #0 $action"
2022-08-29 07:06:50.580 CRITICAL:     (procedure "::dui::page::load" line 23)
2022-08-29 07:06:50.580 CRITICAL:     invoked from within
2022-08-29 07:06:50.580 CRITICAL: "dui page load $page_to_show {*}$args"
2022-08-29 07:06:50.580 CRITICAL:     (procedure "page_display_change" line 2)
2022-08-29 07:06:50.580 CRITICAL:     invoked from within
2022-08-29 07:06:50.580 CRITICAL: "page_display_change "splash" "off""
2022-08-29 07:06:50.580 CRITICAL:     (procedure "run_de1_app" line 2)
2022-08-29 07:06:50.580 CRITICAL:     invoked from within
2022-08-29 07:06:50.580 CRITICAL: "run_de1_app"
2022-08-29 07:06:50.580 CRITICAL:     (procedure "ui_startup" line 73)
2022-08-29 07:06:50.580 CRITICAL:     invoked from within
2022-08-29 07:06:50.580 CRITICAL: "ui_startup"
2022-08-29 07:06:50.580 CRITICAL:     (procedure "de1_ui_startup" line 13)
2022-08-29 07:06:50.580 CRITICAL:     invoked from within
2022-08-29 07:06:50.580 CRITICAL: "de1_ui_startup"
2022-08-29 07:06:50.580 CRITICAL:     ("try" body line 2)} -errorline 2
2022-08-29 07:06:50.583 CRITICAL: Exiting
