### PR TITLE
Support Acaia Pearl 2021 scales

### DIFF
--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -1531,7 +1531,8 @@ proc de1_ble_handler { event data } {
  					|| [string first "PROCH" $name]    == 0 } {
 					append_to_peripheral_list $address $name "ble" "scale" "acaiascale"
 					
-				} elseif {[string first "PEARL" $name] == 0 \
+				} elseif {[string first "PEARLS" $name] == 0 \
+ 					|| [string first "PEARL-" $name]   == 0 \
  					|| [string first "LUNAR" $name]    == 0 \
  					|| [string first "PYXIS" $name]    == 0 } {
 					append_to_peripheral_list $address $name "ble" "scale" "acaiapyxis"

--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -1531,7 +1531,7 @@ proc de1_ble_handler { event data } {
  					|| [string first "PROCH" $name]    == 0 } {
 					append_to_peripheral_list $address $name "ble" "scale" "acaiascale"
 					
-				} elseif {[string first "PEARLS" $name] == 0 \
+				} elseif {[string first "PEARL" $name] == 0 \
  					|| [string first "LUNAR" $name]    == 0 \
  					|| [string first "PYXIS" $name]    == 0 } {
 					append_to_peripheral_list $address $name "ble" "scale" "acaiapyxis"


### PR DESCRIPTION
Support PEARL 2021 scales under the Acaia Pyxis profile, as well as PEARLS.

Pearl 2021 scales appear with the name `PEARL-{last3hex}`

I manually made this change and copied bluetooth.tcl over to my tablet using File Manager+, then tested with my Pearl 2021 scales.

The scales seem to be working correctly (https://visualizer.coffee/shots/e176dd5c-b744-4ea3-a4fd-1b8b6495213b).
