### PR TITLE
DiFluid Microbalance implementation

### DIFF
--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -993,7 +993,7 @@ proc smartchef_parse_response { value } {
 	if {[lindex $binary 3] > 10} {
 		set weight [expr $weight * -1]
 	}
-	::device::scale::process_weight_update [expr $weight / 10.0] ;# $event_time
+	::device::scale::process_weight_update [expr $weight / 10.0] ;
 }
 
 #### Difluid Scale
@@ -1091,7 +1091,7 @@ proc difluid_parse_response { value } {
 		if {[info exists data] } {
 			set weight [scan [string range $data 10 17] %x]
 			if {$weight < 20000} {
-			::device::scale::process_weight_update [expr $weight / 10.0] ;# $event_time
+			::device::scale::process_weight_update [expr $weight / 10.0] ;
 			}
 	}
 

--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -77,9 +77,9 @@ proc scale_timer_stop {} {
 		felicita_stop_timer
 	} elseif {$::settings(scale_type) == "eureka_precisa"} {
 		eureka_precisa_stop_timer
-	}
-	elseif {$::settings(scale_type) == "difluid"} {
+	} elseif {$::settings(scale_type) == "difluid"} {
 		difluid_stop_timer 
+		difluid_reset_timer
 	}
 }
 
@@ -98,9 +98,8 @@ proc scale_timer_reset {} {
 		felicita_timer_reset
 	} elseif {$::settings(scale_type) == "eureka_precisa"} {
 		eureka_precisa_reset_timer
-	}
-	elseif {$::settings(scale_type) == "difluid"} {
-		difluid_reset_timer 
+	} elseif {$::settings(scale_type) == "difluid"} {
+		# moved the reset to the stop function because stop is more like a pause 
 	}
 }
 
@@ -1040,7 +1039,7 @@ if {$::de1(scale_device_handle) == 0 || $::settings(scale_type) != "difluid"} {
 	}
 	set timer_start [binary decode hex "DFDF03020100C4"]
 
-	userdata_append "SCALE: difluid starttimer" [list ble write $::de1(scale_device_handle) $::de1(suuid_difluid) $::sinstance($::de1(suuid_difluid)) $::de1(cuuid_difluid) $::cinstance($::de1(cuuid_difluid))  $timer_start] 0
+	userdata_append "SCALE: difluid starttimer" [list ble write $::de1(scale_device_handle) $::de1(suuid_difluid) $::sinstance($::de1(suuid_difluid)) $::de1(cuuid_difluid) $::cinstance($::de1(cuuid_difluid)) $timer_start] 0
 }
 
 proc difluid_stop_timer {} {
@@ -1054,7 +1053,7 @@ if {$::de1(scale_device_handle) == 0 || $::settings(scale_type) != "difluid"} {
 	}
 	set timer_stop [binary decode hex "DFDF03010100C3"]
 
-	userdata_append "SCALE: difluid stoptimer" [list ble write $::de1(scale_device_handle) $::de1(suuid_difluid) $::sinstance($::de1(suuid_difluid)) $::de1(cuuid_difluid) $::cinstance($::de1(cuuid_difluid))  $timer_stop] 0
+	userdata_append "SCALE: difluid stoptimer" [list ble write $::de1(scale_device_handle) $::de1(suuid_difluid) $::sinstance($::de1(suuid_difluid)) $::de1(cuuid_difluid) $::cinstance($::de1(cuuid_difluid)) $timer_stop] 0
 }
 
 proc difluid_reset_timer {} {
@@ -1068,7 +1067,7 @@ if {$::de1(scale_device_handle) == 0 || $::settings(scale_type) != "difluid"} {
 	}
 	set timer_reset [binary decode hex "DFDF03020100C4"]
 
-	userdata_append "SCALE: difluid resettimer" [list ble write $::de1(scale_device_handle) $::de1(suuid_difluid) $::sinstance($::de1(suuid_difluid)) $::de1(cuuid_difluid) $::cinstance($::de1(cuuid_difluid))  $timer_reset] 0
+	userdata_append "SCALE: difluid resettimer" [list ble write $::de1(scale_device_handle) $::de1(suuid_difluid) $::sinstance($::de1(suuid_difluid)) $::de1(cuuid_difluid) $::cinstance($::de1(cuuid_difluid)) $timer_reset] 0
 }
 
 proc difluid_set_to_grams {} {

--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -955,7 +955,7 @@ proc smartchef_enable_weight_notifications {} {
 	}
 
 	if {[ifexists ::sinstance($::de1(suuid_smartchef))] == ""} {
-		::bt::msg -DEBUG "decent scale not connected, cannot enable weight notifications"
+		::bt::msg -DEBUG "smartchef scale not connected, cannot enable weight notifications"
 		return
 	}
 
@@ -972,7 +972,7 @@ proc smartchef_tare {} {
 		error "Smartchef Scale not connected, cannot send tare cmd"
 		return
 	}
-	
+	borg toast "Press tare button on scale"
 	# set tare [binary decode hex ""] 
 
 	# userdata_append "SCALE: smartchef tare" [list ble write $::de1(scale_device_handle) $::de1(suuid_smartchef) $::sinstance($::de1(suuid_smartchef)) $::de1(cuuid_smartchef_cmd) $::cinstance($::de1(cuuid_smartchef_cmd)) $tare] 0

--- a/de1plus/device_scale.tcl
+++ b/de1plus/device_scale.tcl
@@ -357,6 +357,8 @@ namespace eval ::device::scale {
 			eureka_precisa { eureka_precisa_tare }
 
 			smartchef {smartchef_tare}
+
+			difluid {difluid_tare}
 		}
 
 		set ::device::scale::_tare_last_requested [clock milliseconds]

--- a/de1plus/device_scale.tcl
+++ b/de1plus/device_scale.tcl
@@ -1443,6 +1443,9 @@ namespace eval ::device::scale::callbacks {
 			atomaxskale {
 				set ::device::scale::run_timer True
 			}
+			difluid {
+				set ::device::scale::run_timer True
+			}
 		}
 	}
 

--- a/de1plus/device_scale.tcl
+++ b/de1plus/device_scale.tcl
@@ -355,6 +355,8 @@ namespace eval ::device::scale {
 			hiroiajimmy { hiroia_tare }
 
 			eureka_precisa { eureka_precisa_tare }
+
+			smartchef {smartchef_tare}
 		}
 
 		set ::device::scale::_tare_last_requested [clock milliseconds]

--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -93,6 +93,8 @@ array set ::de1 {
 	suuid_smartchef "0000FFF0-0000-1000-8000-00805F9B34FB"
 	cuuid_smartchef_status "0000FFF1-0000-1000-8000-00805F9B34FB"
 	cuuid_smartchef_cmd "0000FFF2-0000-1000-8000-00805F9B34FB"
+	suuid_difluid "000000EE-0000-1000-8000-00805F9B34FB"
+	cuuid_difluid "0000AA01-0000-1000-8000-00805F9B34FB"
 
 
 	cinstance 0

--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -1187,6 +1187,22 @@ proc check_if_steam_clogged {} {
 
 }
 
+proc check_front_switch {} {
+    set num $::de1(substate)
+	set substate_txt $::de1_substate_types($num)
+	if {$substate_txt != "Error_NoAC" && $::de1(current_context) == "no_ac"} {
+	    page_show off
+	}
+	if {$substate_txt == "Error_NoAC"} {
+	    page_show no_ac
+	}
+	if {$substate_txt == "Error_NoAC"} {
+	    return [translate "Turn the switch on"]
+    } else {
+        return ""
+    }
+}
+
 proc has_flowmeter {} {
 	return $::de1(has_flowmeter)
 }

--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -90,6 +90,10 @@ array set ::de1 {
 	suuid_eureka_precisa "0000FFF0-0000-1000-8000-00805F9B34FB"
 	cuuid_eureka_precisa_status "0000FFF1-0000-1000-8000-00805F9B34FB"
 	cuuid_eureka_precisa_cmd "0000FFF2-0000-1000-8000-00805F9B34FB"
+	suuid_smartchef "0000FFF0-0000-1000-8000-00805F9B34FB"
+	cuuid_smartchef_status "0000FFF1-0000-1000-8000-00805F9B34FB"
+	cuuid_smartchef_cmd "0000FFF2-0000-1000-8000-00805F9B34FB"
+
 
 	cinstance 0
 	fan_threshold 0
@@ -1181,22 +1185,6 @@ proc check_if_steam_clogged {} {
 		#msg -DEBUG "check_if_steam_clogged found no problem"	
 	}
 
-}
-
-proc check_front_switch {} {
-    set num $::de1(substate)
-	set substate_txt $::de1_substate_types($num)
-	if {$substate_txt != "Error_NoAC" && $::de1(current_context) == "no_ac"} {
-	    page_show off
-	}
-	if {$substate_txt == "Error_NoAC"} {
-	    page_show no_ac
-	}
-	if {$substate_txt == "Error_NoAC"} {
-	    return [translate "Turn the switch on"]
-    } else {
-        return ""
-    }
 }
 
 proc has_flowmeter {} {


### PR DESCRIPTION
Implementation of the DiFluid Microbalance, including auto-tare and timer.
When the scale connects the auto-notifications are enabled and it is set to report in grams.

Documentation can be found here: https://github.com/DiFluid/difluid-sdk-demo/blob/master/docs/protocolMicrobalance.md
The scale needs to run on Firmware Version 3.0.0+