### PR TITLE
Dui fix longpress

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -6889,8 +6889,8 @@ namespace eval ::dui {
 			}]]
 		}
 		
-		proc longpress_unpress { widget_name {press_command {}} } {
-			variable longpress_timer			
+		proc longpress_unpress { widget_name  {press_command {}} } {
+			variable longpress_timer
 			if { $longpress_timer ne {} } {
 				after cancel $longpress_timer
 				set ::dui::item::longpress_timer {}


### PR DESCRIPTION
This fixes the bugs spotted by @Damian-AU when developing the P&D skin.
 - Now short presses shouldn't generate long presses under some circunstances, like before
 - The default threshold to distinguish between short and long presses have been increased from 200 to 300 milliseconds
 - `dbutton` widget gains a new argument `-longpress_threshold` that allows modifying the number of milliseconds to trigger a longpress event on every dbutton.