### PR TITLE
DUI fixes (z-order, longpress, retheme, dbutton corners)

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -7705,33 +7705,33 @@ namespace eval ::dui {
 
 			if { $radius1 > 0 } {
 				lappend ids [$can create arc $x0 [expr {$y0+$radius1+1.0}] [expr {$x0+$radius1+1.0}] $y0 -style arc -outline $colour \
-					-width $arc_width -tags [list ${main_tag}-nw {*}$tags] -start 90 -disabledoutline $disabled -state "hidden"]
+					-width $arc_width -tags [list ${main_tag}-nw ${main_tag}-cor {*}$tags] -start 90 -disabledoutline $disabled -state "hidden"]
 			}
 			if { $radius2 > 0 } {
 				lappend ids [$can create arc [expr {$x1-$radius2-1}] $y0 $x1 [expr {$y0+$radius2+1}] -style arc -outline $colour \
-					-width $arc_width -tags [list ${main_tag}-ne {*}$tags] -start 0 -disabledoutline $disabled -state "hidden"]
+					-width $arc_width -tags [list ${main_tag}-ne ${main_tag}-cor {*}$tags] -start 0 -disabledoutline $disabled -state "hidden"]
 			}
 			if { $radius3 > 0 } {
 				lappend ids [$can create arc [expr {$x1-$radius3-1.0}] $y1 $x1 [expr {$y1-$radius3-1.0}] -style arc -outline $colour \
-					-width $arc_width -tags [list ${main_tag}-se {*}$tags] -start -90 -disabledoutline $disabled -state "hidden"]
+					-width $arc_width -tags [list ${main_tag}-se ${main_tag}-cor {*}$tags] -start -90 -disabledoutline $disabled -state "hidden"]
 			}			
 			if { $radius4 > 0 } {
 				lappend ids [$can create arc $x0 [expr {$y1-$radius4-1.0}] [expr {$x0+$radius4+1.0}] $y1 -style arc -outline $colour \
-					-width $arc_width -tags [list ${main_tag}-sw {*}$tags] -start 180 -disabledoutline $disabled -state "hidden"]
+					-width $arc_width -tags [list ${main_tag}-sw ${main_tag}-cor {*}$tags] -start 180 -disabledoutline $disabled -state "hidden"]
 			}
 
 			# Top line
 			lappend ids [$can create line [expr {$x0+$radius1/2.0-1.0}] $y0 [expr {$x1-$radius2/2.0+1.0}] $y0 -fill $colour \
-				-width $width -tags [list ${main_tag}-n {*}$tags] -disabledfill $disabled -state "hidden"]
+				-width $width -tags [list ${main_tag}-n ${main_tag}-lin {*}$tags] -disabledfill $disabled -state "hidden"]
 			# Right line
 			lappend ids [$can create line $x1 [expr {$y0+$radius2/2.0-1.0}] $x1 [expr {$y1-$radius3/2.0+1.0}] -fill $colour \
-				-width $width -tags [list ${main_tag}-e {*}$tags] -disabledfill $disabled -state "hidden"]
+				-width $width -tags [list ${main_tag}-e ${main_tag}-lin {*}$tags] -disabledfill $disabled -state "hidden"]
 			# Bottom line
 			lappend ids [$can create line [expr {$x0+$radius4/2.0-1.0}] $y1 [expr {$x1-$radius3/2.0+1.0}] $y1 -fill $colour \
-				-width $width -tags [list ${main_tag}-s {*}$tags] -disabledfill $disabled -state "hidden"]
+				-width $width -tags [list ${main_tag}-s ${main_tag}-lin {*}$tags] -disabledfill $disabled -state "hidden"]
 			# Left line
 			lappend ids [$can create line $x0 [expr {$y0+$radius1/2.0-1.0}] $x0 [expr {$y1-$radius4/2.0+1.0}] -fill $colour \
-				-width $width -tags [list ${main_tag}-w {*}$tags] -disabledfill $disabled -state "hidden"]
+				-width $width -tags [list ${main_tag}-w ${main_tag}-lin {*}$tags] -disabledfill $disabled -state "hidden"]
 			return $ids
 		}
 		

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -6400,11 +6400,7 @@ namespace eval ::dui {
 					msg -WARNING [namespace current] "page '$page_to_show' has no visual items to show"
 				}
 			
-				if { $show_page_type eq "dialog" } {
-					set previous_item $page_to_show
-				} else {
-					set previous_item [$can find withtag pages&&$page_to_show]
-				}
+				set previous_item $page_to_show
 				foreach item $items_to_show {
 					set item_type [$can type $item]
 					if { !$preload_images && $item_type eq "image" } {
@@ -6439,7 +6435,7 @@ namespace eval ::dui {
 							$can itemconfigure $item -state $state
 						}
 						
-						if { $previous_item ne {} } {
+						if { $show_page_type eq "dialog" && $previous_item ne {} } {
 							# Ensure the z-order stack is properly maintained 
 							$can raise $item $previous_item
 						}
@@ -6651,6 +6647,10 @@ namespace eval ::dui {
 					foreach page $pages {
 						if { "p:$page" ni $item_tags } {
 							lappend item_tags "p:$page"
+							set page_id [$can find withtag $page]
+							if { $page_id ne {} } {
+								$can raise $id $page
+							}
 							set changed 1
 						}
 					}

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -8307,6 +8307,9 @@ namespace eval ::dui {
 		}
 		
 		proc longpress_press { widget_name longpress_command {longpress_threshold 0}} {
+			variable longpress_timer
+			after cancel $longpress_timer
+			
 			variable longpress_default_threshold
 			if { $longpress_threshold <= 0 } {
 				set longpress_threshold $longpress_default_threshold

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -5958,7 +5958,7 @@ namespace eval ::dui {
 		proc retheme { pages new_theme {force 0} } {
 			if { ![dui theme exists $new_theme] } {
 				msg -ERROR [namespace current] retheme: "new theme '$new_theme' is not a valid theme"
-				return $is_rethemed
+				return 0
 			}
 			
 			if { [string is true $force] } {

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -90,6 +90,8 @@ namespace eval ::dui {
 		variable listbox_length_multiplier
 		variable listbox_global_width_multiplier
 
+		set settings(app_title) $::settings(skin)
+		
 		if { ![info exists ::loaded_fonts] } {
 			set loaded_fonts {}
 		}
@@ -11363,26 +11365,5 @@ namespace eval ::dui::pages::dui_confirm_dialog {
 		return 1
 	}
 
-}
-
-##################################################################################################
-# UI related convenience procs below, moved over from Mimoja Cafe so they can be generally used
-
-proc rectangle {contexts x1 y1 x2 y2 colour } {
-	catch {
-		if {$::iconik_transparent_theme} {
-			return
-		}
-	}
-	set x1 [rescale_x_skin $x1] 
-	set y1 [rescale_y_skin $y1] 
-	set x2 [rescale_x_skin $x2] 
-	set y2 [rescale_y_skin $y2]
-	if { [info exists ::_rect_id] != 1 } { set ::_rect_id 0 }
-	set tag "rect_$::_rect_id"
-    .can create rectangle $x1 $y1 $x2 $y2 -fill $colour -outline $colour -width 0 -tag $tag -state "hidden"
-	add_visual_items_to_contexts $contexts $tag
-	incr ::_rect_id
-	return $tag
 }
 

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -90,10 +90,6 @@ namespace eval ::dui {
 		variable listbox_length_multiplier
 		variable listbox_global_width_multiplier
 
-
-		set settings(app_title) $::settings(skin)
-
-
 		if { ![info exists ::loaded_fonts] } {
 			set loaded_fonts {}
 		}
@@ -6404,7 +6400,11 @@ namespace eval ::dui {
 					msg -WARNING [namespace current] "page '$page_to_show' has no visual items to show"
 				}
 			
-				set previous_item $page_to_show
+				if { $show_page_type eq "dialog" } {
+					set previous_item $page_to_show
+				} else {
+					set previous_item [$can find withtag pages&&$page_to_show]
+				}
 				foreach item $items_to_show {
 					set item_type [$can type $item]
 					if { !$preload_images && $item_type eq "image" } {
@@ -6439,7 +6439,7 @@ namespace eval ::dui {
 							$can itemconfigure $item -state $state
 						}
 						
-						if { $show_page_type eq "dialog" && $previous_item ne {} } {
+						if { $previous_item ne {} } {
 							# Ensure the z-order stack is properly maintained 
 							$can raise $item $previous_item
 						}
@@ -6637,7 +6637,7 @@ namespace eval ::dui {
 		#	the job.
 		proc add_items { pages tags } {
 			set can [dui canvas]
-			
+
 			foreach tag $tags {
 				if { [string is integer $tag] } {
 					set ids $tag
@@ -6647,14 +6647,17 @@ namespace eval ::dui {
 				
 				foreach id $ids {
 					set item_tags [$can gettags $id]
+					set changed 0
 					foreach page $pages {
 						if { "p:$page" ni $item_tags } {
 							lappend item_tags "p:$page"
+							set changed 1
 						}
 					}
-					
-					msg -DEBUG [namespace current] add_items "with tag(s) '$item_tags' to page(s) '$pages'"
-					$can itemconfigure $tag -tags $item_tags
+					if {$changed == 1} {
+						$can itemconfigure $id -tags $item_tags	
+						msg -DEBUG [namespace current] add_items "with tag(s) '$id' to page(s) '$pages'"
+					}
 				}
 			}
 		}


### PR DESCRIPTION
A few minor DUI bug fixes that were pending:

1. Adding items already added to a page to another page using ``dui::page::add_items`` could make the items non-visible due to z-order problems. Fixed. Solves issue #282 

2. A possible fix for the problem of DUI longpresses of dbuttons in android, as described in issue #280. This seems to fix it on my tests but as the problem is hard to reproduce, I need @Damian-AU to check and verify.

3. ``dui::page::retheme`` would raise a runtime error due to an undefined-variable return value if the new_theme didn't exist, as reported by @decentjohn on issue #288, fixed.

4. DUI "round outline" dbutton corners now share a common tag suffix ``<main_tag>-out-cor`` so they can be modified at once. The straight lines in the outline also receive a new common tag suffix ``<main_tag>-out-lin``. See issue #292.