### PR TITLE
DUI Fixes

### DIFF
--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -8902,8 +8902,18 @@ namespace eval ::dui {
 				}
 				
 				set "label${suffix}_pos" [dui::args::get_option -pos {0.5 0.5} 1 "label${suffix}_args"]
-				set "xlabel$suffix" [expr {$x+int($x1-$x)*[lindex [subst \$label${suffix}_pos] 0]}]
-				set "ylabel$suffix" [expr {$y+int($y1-$y)*[lindex [subst \$label${suffix}_pos] 1]}]
+				set lx [lindex [subst \$label${suffix}_pos] 0]
+				set ly [lindex [subst \$label${suffix}_pos] 1]
+				if { $lx >= 0.0 && $lx <= 1.0} {
+					set "xlabel$suffix" [expr {$x+int($x1-$x)*$lx}]
+				} else {
+					set "xlabel$suffix" [expr {$x+$lx}]
+				}
+				if { $ly >= 0.0 && $ly <= 1.0 } {
+					set "ylabel$suffix" [expr {$y+int($y1-$y)*$ly}]
+				} else {
+					set "ylabel$suffix" [expr {$y+$ly}]
+				}
 				
 				set suffix [incr i]
 				set "label$suffix" [dui::args::get_option "-label$suffix" "" 1]
@@ -8919,13 +8929,24 @@ namespace eval ::dui {
 				set "symbol${suffix}_args" [dui::args::extract_prefixed "-symbol${suffix}_"]
 				
 				foreach aspect [dui aspect list -type [list "${aspect_type}_symbol$suffix" symbol] -style $style] {
-					dui::args::add_option_if_not_exists -$aspect [dui aspect get "${aspect_type}_symbol$suffix" $aspect -style $style \
+					dui::args::add_option_if_not_exists -$aspect \
+						[dui aspect get "${aspect_type}_symbol$suffix" $aspect -style $style \
 						-default {} -default_type symbol] "symbol${suffix}_args"
 				}
 				
 				set "symbol${suffix}_pos" [dui::args::get_option -pos {0.5 0.5} 1 "symbol${suffix}_args"]
-				set "xsymbol$suffix" [expr {$x+int($x1-$x)*[lindex [subst \$symbol${suffix}_pos] 0]}]
-				set "ysymbol$suffix" [expr {$y+int($y1-$y)*[lindex [subst \$symbol${suffix}_pos] 1]}]
+				set lx [lindex [subst \$symbol${suffix}_pos] 0]
+				set ly [lindex [subst \$symbol${suffix}_pos] 1]
+				if { $lx >= 0.0 && $lx <= 1.0 } {
+					set "xsymbol$suffix" [expr {$x+int($x1-$x)*$lx}]
+				} else {
+					set "xsymbol$suffix" [expr {$x+$lx}]
+				}
+				if { $ly >= 0.0 && $ly <= 1.0 } {
+					set "ysymbol$suffix" [expr {$y+int($y1-$y)*$ly}]
+				} else {
+					set "ysymbol$suffix" [expr {$y+$ly}]
+				}
 				
 				set suffix [incr i]
 				set "symbol$suffix" [dui::args::get_option "-symbol$suffix" "" 1]

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -8483,11 +8483,18 @@ namespace eval ::dui {
 		
 		# Paint each dtoggle control compound item, to refelect the value of its boolean variable.
 		# Needs 'args' at the end because this is called from a 'trace add variable'.
-		proc dtoggle_draw { page main_tag varname x0 y0 x1 y1 sliderwidth outline_width foreground selectedforeground 
+		proc dtoggle_draw { page main_tag varname sliderwidth outline_width foreground selectedforeground 
 				background selectedbackground outline selectedoutline args } {
 			set can [dui::canvas]
 			set curval [subst \$$varname]
 			
+			# Original coordinates passed to the proc don't work if the dtoggle has been moved
+			lassign [$can coords [dui item get $page ${main_tag}-bck]] x0 y0 x1 y1
+			set x0 [expr {$x0-$sliderwidth/2.0}] 
+			set y0 [expr {$y0-$sliderwidth/2.0}]
+			set x1 [expr {$x1+$sliderwidth/2.0}] 
+			set y1 [expr {$y1+$sliderwidth/2.0}]
+					
 			if { [string is true $curval] } {
 				dui item config $page ${main_tag}-bck -fill $selectedbackground
 				dui item config $page ${main_tag}-crc -fill $selectedforeground
@@ -9447,8 +9454,8 @@ namespace eval ::dui {
 			set cmd [::list ::dui::item::dtoggle_click $var]
 			$can bind $id [dui::platform::button_press] $cmd
 
-			set draw_cmd [::list ::dui::item::dtoggle_draw [lindex $pages 0] $main_tag $var $x $y $x1 $y1 \
-				$sliderwidth $outline_width $foreground $selectedforeground $background $selectedbackground \
+			set draw_cmd [::list ::dui::item::dtoggle_draw [lindex $pages 0] $main_tag $var $sliderwidth \
+				$outline_width $foreground $selectedforeground $background $selectedbackground \
 				$outline $selectedoutline]
 			# Initialize the control
 			uplevel #0 $draw_cmd

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -8369,6 +8369,7 @@ namespace eval ::dui {
 		
 		proc dbutton_press { main_tag press_command args } {
 			variable longpress_timer
+
 			# Handles a bug in android which doesn't seem to cancel timers properly 
 			after cancel $longpress_timer
 			set ::dui::item::longpress_timer {}
@@ -8421,7 +8422,7 @@ namespace eval ::dui {
 			}
 		}
 		
-		proc longpress_press { widget_name longpress_command {longpress_threshold 0}} {
+		proc longpress_press { main_tag longpress_command {longpress_threshold 0}} {
 			variable longpress_timer
 			variable longpress_default_threshold
 			
@@ -8436,6 +8437,13 @@ namespace eval ::dui {
 				set ::dui::item::longpress_timer {}
 				uplevel #0 $longpress_command
 			}]]
+		}
+
+		proc longpress_unpress { main_tag press_command args } {
+			variable longpress_timer
+			if { $longpress_timer ne {} } {
+				dbutton_press $main_tag $press_command $args
+			} 
 		}
 		
 		# Run when any of the buttons in a dselector is tapped. This relies on the target variable having a 
@@ -9230,19 +9238,19 @@ namespace eval ::dui {
 				msg -DEBUG [namespace current] dbutton "'$main_tag' in page(s) '$pages' does not have a command"
 
 				if { $longpress_cmd ne "" } {
-					$can bind $id [dui::platform::button_press] [list ::dui::item::longpress_press $id \
+					$can bind $id [dui::platform::button_press] [list ::dui::item::longpress_press $main_tag \
 							$longpress_cmd $longpress_threshold]
 					$can bind $id [dui::platform::button_unpress] \
-							[list ::dui::item::dbutton_press $main_tag $cmd {*}$press_args] 
+							[list ::dui::item::longpress_unpress $main_tag $cmd {*}$press_args] 
 				}
 			} elseif { $longpress_cmd eq "" } {
 				$can bind $id [dui::platform::button_press] [list ::dui::item::dbutton_press $main_tag \
 					$cmd {*}$press_args]
 			} else {
-				$can bind $id [dui::platform::button_press] [list ::dui::item::longpress_press $id \
+				$can bind $id [dui::platform::button_press] [list ::dui::item::longpress_press $main_tag \
 						$longpress_cmd $longpress_threshold]
 				$can bind $id [dui::platform::button_unpress] \
-					[list ::dui::item::dbutton_press $main_tag $cmd {*}$press_args] 
+					[list ::dui::item::longpress_unpress $main_tag $cmd {*}$press_args] 
 			}
 			
 			if { $ns ne "" } {

--- a/de1plus/dui.tcl
+++ b/de1plus/dui.tcl
@@ -6930,7 +6930,7 @@ namespace eval ::dui {
 		variable press_events
 		array set press_events {}
 		# Milliseconds to distinguish between press and longpress
-		variable longpress_default_threshold 300
+		variable longpress_default_threshold 1500
 		# Current longpress "after" event
 		variable longpress_timer {}
 	
@@ -8423,9 +8423,11 @@ namespace eval ::dui {
 		
 		proc longpress_press { widget_name longpress_command {longpress_threshold 0}} {
 			variable longpress_timer
-			after cancel $longpress_timer
-			
 			variable longpress_default_threshold
+			
+			after cancel $longpress_timer
+			set ::dui::item::longpress_timer {}
+			
 			if { $longpress_threshold <= 0 } {
 				set longpress_threshold $longpress_default_threshold
 			}


### PR DESCRIPTION
This fixes a couple of pending problems in DUI and adds some new features:

- Change the default longpress threshold time from 300 to 1500 ms, as per PulakB recommendation.
- Add new options ``-pressfill``, ``-labelN_pressfill``, and ``-symbolN_pressfill`` to ``dui::add::dbutton``. These allow to change the colors of button backgrounds and labels when a button is pressed. All 3 take a list of colors and integer times in milliseconds for each color change, and at the end always revert back to the original colors. If some times are not provided, will change to each new color (from left to right in the list) every 40 ms. If only one color is given, will change it for 200 ms.
- Allow label and symbol coordinates inside dbuttons (as given by options ``-label_pos`` and ``-symbol_pos``) to accept absolute coordinates. Values between 0.0 and 1.0 are still interpreted as percentage coordinates, but values bigger than 1.0 are assumed to be absolute coordinates from the top-left corner of the button.
- Fix a bug in ``dui::item::dtoggle`` that, when the "widget" was moved at runtime, would show the center circle in the original coordinates.

I'm not automatically merging this as DUI modifications can have unforeseen side effects and I prefer this to be reviewed before merging. I have had these changes for one week on my tablet, and tested all major skins on my PC, and have found no problem.