### PR TITLE
Add mqtt plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -48,3 +48,7 @@
 [submodule "de1plus\\skins\\DSx2"]
 	path = de1plus\\skins\\DSx2
 	url = https://github.com/Damian-AU/DSx2
+[submodule "de1plus/plugins/mqtt"]
+	path = de1plus/plugins/mqtt
+	url = https://github.com/simpkins/de1plus-mqtt.git
+	branch = main


### PR DESCRIPTION
This adds my MQTT plugin, so it can be present as part of the default install without users needing to manually copy it on to their tablet.  Here is the thread discussing the plugin: https://3.basecamp.com/3671212/buckets/7351439/messages/6317898181

If you prefer, I'm also fine with the MQTT plugin being moved directly into the de1app repository rather than being a submodule.  This would perhaps make it easier to be kept in sync with the de1app code if there are ever any changes to de1app code that require changes to the MQTT plugin.  I'm happy assigning copyright ownership as needed.