### PR TITLE
More DPx_Flow_Calibrator cleanup

### DIFF
--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -462,7 +462,7 @@ array set ::settings {
 	comms_debugging 0
 	scale_stop_at_half_shot 0
 	lock_screen_during_screensaver 0
-	enabled_plugins {visualizer_upload D_Scheduler DPx_Flow_Calibrator D_Flow_Espresso_Profile}
+	enabled_plugins {visualizer_upload D_Scheduler D_Flow_Espresso_Profile}
 
 	maximum_flow 0
 	maximum_flow_range_default 1.0

--- a/de1plus/plugins.tcl
+++ b/de1plus/plugins.tcl
@@ -186,9 +186,6 @@ namespace eval ::plugins {
             } elseif {[string tolower $fbasename] == "skip_first_step_notice"} {
                 # per Damian's suggestion, should not be part of STABLE
                 continue
-            } elseif {$fbasename == "DPx_Flow_Calibrator"} {
-                # per Damian's suggestion, should not be part of the app
-                continue
             }
 
             ############################################################


### PR DESCRIPTION
More DPx_Flow_Calibrator cleanup. In addition to this users will have to removed DPx_Flow_Calibrator from settings.tdb.