### PR TITLE
Fix some Varia scale integration bugs

### DIFF
--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -1520,13 +1520,13 @@ proc varia_aku_parse_response { value } {
     if {$command == 0x01 && $length == 0x03} {
 			binary scan $payload cucucucu w1 w2 w3 xor
 
-			# Pull out the sign via bitmask. The Varia API docs say that the sign bit is in the highest
-			# bit, but from their docs (and empirically), it's actually the highest nibble. When the 
-			# highest nibble is 1, then it's negative. Otherwise, it's positive.
+			# Pull out the sign via bitmask. The Varia API docs say that the sign bit is encoded in the
+			# highest bit, but from their docs (and empirically), it's actually the highest nibble. When 
+			# the highest nibble is 1, then the weight is negative. Otherwise, it's positive.
 			set sign [expr {$w1 & 0x10}]
 
 			# Combine the three bytes to get the weight (assuming big-endian order)
-			# Also strip off the sign nibble from the largest digit.
+			# Also strip off the sign nibble.
 			set weight100 [expr {(([expr {$w1 & 0x0F}] << 16) | ($w2 << 8) | $w3)/100.0}]
 
 			if {$sign > 0} {

--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -1520,13 +1520,14 @@ proc varia_aku_parse_response { value } {
     if {$command == 0x01 && $length == 0x03} {
 			binary scan $payload cucucucu w1 w2 w3 xor
 
-			# Pull out the sign via bitmask. As per the Varia API docs, the sign is encoded in
-			# the highest bit.
-			set sign [expr {$w1 & 0x80}]
+			# Pull out the sign via bitmask. The Varia API docs say that the sign bit is in the highest
+			# bit, but from their docs (and empirically), it's actually the highest nibble. When the 
+			# highest nibble is 1, then it's negative. Otherwise, it's positive.
+			set sign [expr {$w1 & 0x10}]
 
 			# Combine the three bytes to get the weight (assuming big-endian order)
-			# Also strip off the sign bit from the largest digit
-			set weight100 [expr {(([expr {$w1 & 0x7F}] << 16) | ($w2 << 8) | $w3)/100.0}]
+			# Also strip off the sign nibble from the largest digit.
+			set weight100 [expr {(([expr {$w1 & 0x0F}] << 16) | ($w2 << 8) | $w3)/100.0}]
 
 			if {$sign > 0} {
 				set weight100 [expr {-1 * $weight100}]

--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -104,8 +104,8 @@ array set ::de1 {
 	cuuid_smartchef_cmd "0000FFF2-0000-1000-8000-00805F9B34FB"
 	suuid_difluid "000000EE-0000-1000-8000-00805F9B34FB"
 	cuuid_difluid "0000AA01-0000-1000-8000-00805F9B34FB"
-	suuid_varia_aku "FFF0"
-	cuuid_varia_aku "FFF1"
+	suuid_varia_aku "0000FFF0-0000-1000-8000-00805F9B34FB"
+	cuuid_varia_aku "0000FFF1-0000-1000-8000-00805F9B34FB"
 	cuuid_varia_aku_cmd "FFF2"
 
 


### PR DESCRIPTION
This PR fixes two bugs:

1. Negative weight values are now parsed properly from the payload
2. Use the correct service UUID channels for the scale