### PR TITLE
Fix Varia AKU tare issue

### DIFF
--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -106,7 +106,7 @@ array set ::de1 {
 	cuuid_difluid "0000AA01-0000-1000-8000-00805F9B34FB"
 	suuid_varia_aku "0000FFF0-0000-1000-8000-00805F9B34FB"
 	cuuid_varia_aku "0000FFF1-0000-1000-8000-00805F9B34FB"
-	cuuid_varia_aku_cmd "FFF2"
+	cuuid_varia_aku_cmd "0000FFF2-0000-1000-8000-00805F9B34FB"
 
 
 	cinstance 0


### PR DESCRIPTION
This PR should fix the [error that was seen when trying to tare AKU scales](https://3.basecamp.com/3671212/buckets/7351439/messages/7090482794#__recording_8344601044).