### PR TITLE
Fix the scale weight misreporting and remove unused code

### DIFF
--- a/de1plus/device_scale.tcl
+++ b/de1plus/device_scale.tcl
@@ -796,12 +796,13 @@ namespace eval ::device::scale::history {
 	proc flow_fd {} {
 
 		variable _scale_raw_weight
+		variable _scale_raw_arrival
 
 		if {[llength $_scale_raw_weight] < [samples_for_estimate]} {return 0}
 
 		set intervals [ expr { [samples_for_estimate] - 1 }]
 		expr { ( [lindex $_scale_raw_weight end] - [lindex $_scale_raw_weight end-$intervals] ) \
-			       / ( [::device::scale::period::estimate] * $intervals ) }
+			       / ( [lindex $_scale_raw_arrival end] - [lindex $_scale_raw_arrival end-$intervals] ) }
 	}
 
 


### PR DESCRIPTION
Use the actual time to calculate weight flow and remove the unused LSLR and period estimation code.

Fixes #331

Shot pulled: https://visualizer.coffee/shots/a00932fd-baf2-4a58-93c5-bad425ee108c

CC @jeffsf 