### PR TITLE
Scale: fix connectivity for older Acaia Lunar scales

### DIFF
--- a/de1plus/device_scale.tcl
+++ b/de1plus/device_scale.tcl
@@ -348,8 +348,8 @@ namespace eval ::device::scale {
 
 			decentscale { decentscale_tare }
 
-			acaiascale { acaia_tare $::de1(suuid_acaia_ips) $::de1(cuuid_acaia_ips_age) }
-			acaiapyxis { acaia_tare $::de1(suuid_acaia_pyxis) $::de1(cuuid_acaia_pyxis_cmd) }
+			acaiascale { acaia_tare $::de1(suuid_acaia_ips) $::de1(cuuid_acaia_ips_age) 1 }
+			acaiapyxis { acaia_tare $::de1(suuid_acaia_pyxis) $::de1(cuuid_acaia_pyxis_cmd) 2 }
 
 
 			felicita { felicita_tare }


### PR DESCRIPTION
Recent versions of AndroWish appear to have a bug in the "ble write" behavior: if the write type is not explicitly specified it now always performs the write using `WRITE_TYPE_DEFAULT` rather than the write type advertised by the device.

Older Acaia Lunar scales advertise their command characteristic as `WRITE_TYPE_NO_RESPONSE`, and reject the write with a permission denied error if you attempt to write using `WRITE_TYPE_DEFAULT`.  The problem is made worse by the fact that AndroWish currently does not pass write errors back to the tcl callback: this results in the tcl bluetooth write queue getting stuck since it never receives a callback indicating that the outstanding write finished.

This fixes the code by explicitly specifying the write type when performing writes to Acaia scales. While we could remember the write type from the characteristic advertisement, simply hard-coding the values seems simpler and appears to be recommended anyway by many online sources since apparently there are a number BLE devices that advertise their write types incorrectly.

I submitted an upstream ticket to AndroWish about the `ble write` behavior: https://androwish.org/home/tktview/41158fb27522c3083447c63fedf60f2011dec194