### PR TITLE
update a-flow to v2.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -61,9 +61,6 @@
 [submodule "de1plus/plugins/history_exclusion_filter"]
 	path = de1plus/plugins/history_exclusion_filter
 	url = https://github.com/Damian-AU/history_exclusion_filter
-[submodule "de1plus/plugins/A_Flow"]
-	path = de1plus/plugins/A_Flow
-	url = https://github.com/Jan3kJ/A_Flow.git
 [submodule "de1plus/profile_editors/D_Flow"]
 	path = de1plus/profile_editors/D_Flow
 	url = https://github.com/Damian-AU/D_Flow


### PR DESCRIPTION
A-Flow v2.1: bugfix release for new integration as profile editor
- profile load issue (advanced editor was shown and/or wrong values loaded)
- copy of default profiles if not existing

see discussion here: https://3.basecamp.com/3671212/buckets/7351439/messages/9240240744

In addition obsolete A-Flow plugin has been removed. 

Tested on latest nightly