### PR TITLE
Update AtomHeart Eclair scale BLE handling

### DIFF
--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -551,7 +551,26 @@ proc atomheart_eclair_enable_weight_notifications {} {
 		return
 	}
 
-	userdata_append "SCALE: enable atomheart_eclair scale weight notifications" [list ble enable $::de1(scale_device_handle) $::de1(suuid_atomheart_eclair) $::sinstance($::de1(suuid_atomheart_eclair)) $::de1(cuuid_atomheart_eclair) $::cinstance($::de1(cuuid_atomheart_eclair))] 1
+	if {[::device::scale::is_reporting]} {
+		return
+	}
+
+	set comment "SCALE: enable atomheart_eclair scale weight notifications"
+	set cmd [list ble enable $::de1(scale_device_handle) $::de1(suuid_atomheart_eclair) $::sinstance($::de1(suuid_atomheart_eclair)) $::de1(cuuid_atomheart_eclair) $::cinstance($::de1(cuuid_atomheart_eclair))]
+
+	foreach queued_cmd $::de1(cmdstack) {
+		if {[lindex $queued_cmd 0] == $comment} {
+			return
+		}
+	}
+
+	if {[llength $::de1(cmdstack)] > 0} {
+		set ::de1(cmdstack) [linsert $::de1(cmdstack) 0 [list $comment $cmd 1]]
+		after 1 run_next_userdata_cmd
+		return
+	}
+
+	userdata_append $comment $cmd 1
 }
 
 proc atomheart_eclair_tare {} {
@@ -581,8 +600,7 @@ proc atomheart_eclair_timer_reset {} {
 		error "atomheart_eclair Scale not connected, cannot send timer cmd"
 		return
 	}
-	# Eclair scale no dedicated timer reset command, timer will reset automatically after the scale receive the tare comand. So this comand is the same as the tare comand.
-	set timer_reset [binary decode hex "540101"]
+	set timer_reset [binary decode hex "520101"]
 
 	userdata_append "SCALE: atomheart_eclair timer_reset" [list ble write $::de1(scale_device_handle) $::de1(suuid_atomheart_eclair) $::sinstance($::de1(suuid_atomheart_eclair)) $::de1(cuuid_atomheart_eclair_cmd) $::cinstance($::de1(cuuid_atomheart_eclair_cmd)) $timer_reset] 0
 
@@ -598,7 +616,7 @@ proc atomheart_eclair_start_timer {} {
 		return
 	}
 
-	set timer_start [binary decode hex "430101"]
+	set timer_start [binary decode hex "530101"]
 
 	userdata_append "SCALE: atomheart_eclair timer_start" [list ble write $::de1(scale_device_handle) $::de1(suuid_atomheart_eclair) $::sinstance($::de1(suuid_atomheart_eclair)) $::de1(cuuid_atomheart_eclair_cmd) $::cinstance($::de1(cuuid_atomheart_eclair_cmd)) $timer_start] 0
 
@@ -614,7 +632,7 @@ proc atomheart_eclair_stop_timer {} {
 		return
 	}
 
-	set timer_stop [binary decode hex "430000"]
+	set timer_stop [binary decode hex "450101"]
 
 	userdata_append "SCALE: atomheart_eclair timer_stop" [list ble write $::de1(scale_device_handle) $::de1(suuid_atomheart_eclair) $::sinstance($::de1(suuid_atomheart_eclair)) $::de1(cuuid_atomheart_eclair_cmd) $::cinstance($::de1(cuuid_atomheart_eclair_cmd)) $timer_stop] 0
 
@@ -2025,7 +2043,7 @@ proc ble_connect_to_scale {} {
 		return 0
 	}
 
-	if {[llength $::de1(cmdstack)] > 2} {
+	if {[llength $::de1(cmdstack)] > 2 && $::settings(scale_type) != "atomheart_eclair"} {
 		::bt::msg -INFO "Too much backpressure, waiting with the connect"
 		::comms::msg -INFO "Current cmd: ([llength $::de1(cmdstack)]) >>>" \
 			[lindex [lindex $::de1(cmdstack) 0] 0]
@@ -2403,6 +2421,7 @@ proc de1_ble_handler { event data } {
 						} elseif {$::settings(scale_type) == "atomheart_eclair"} {
 							append_to_peripheral_list $address $::settings(scale_bluetooth_name) "ble" "scale" "atomheart_eclair"
 							after 200 atomheart_eclair_enable_weight_notifications
+							after 800 atomheart_eclair_enable_weight_notifications
 						} elseif {$::settings(scale_type) == "acaiascale"} {
 							append_to_peripheral_list $address $::settings(scale_bluetooth_name) "ble" "scale" "acaiascale"
 							set ::settings(force_acaia_heartbeat) 0


### PR DESCRIPTION
## Summary
- Update AtomHeart Eclair timer commands to match the current firmware protocol: reset uses `R 01 01`, start uses `S 01 01`, and stop uses `E 01 01`.
- Make Eclair weight notification setup idempotent and prioritize it after reconnects so weight updates resume promptly even when the DE1 command queue is busy.
- Allow Eclair scale reconnects to proceed while the DE1 command queue has backpressure; other scale types keep the existing queue behavior.

## Background
AtomHeart is an independent coffee hardware studio founded by OPC in 2022. Eclair is AtomHeart's Bluetooth coffee scale, currently used with integrations such as Gaggiuino and Decent Espresso workflows. This update keeps the existing Eclair support aligned with the newer Eclair firmware behavior and improves reconnect stability during brew-page use.

## Testing
- Tested with an AtomHeart Eclair scale on firmware v2.1.x and de1app on an Android tablet over several days.
- Repeatedly power-cycled the scale from both the settings page and brew page.
- Confirmed automatic reconnect, prompt weight update recovery after reconnect, and normal tare/reset/start/stop timer behavior.
- Checked Tcl syntax with `tclsh` `info complete` and verified no diagnostic logging remains.
