### PR TITLE
Fix stale scale notification recovery

### DIFF
--- a/de1plus/binary.tcl
+++ b/de1plus/binary.tcl
@@ -204,7 +204,7 @@ proc return_de1_packed_steam_hotwater_settings { {temporarily_disable_steam 0} }
 
 	set arr(TargetHotWaterTemp) [convert_float_to_U8P0 $::settings(water_temperature)]
 	
-	if {$::de1(scale_device_handle) != 0} {
+	if {[::device::scale::is_operational]} {
 		# "hot water: stop on weight" feature. Works with the scale, so it's more accurate.
 		# we ask for more water than we need, so that we can definitely get enough
 		# to stop on weight.

--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -3045,6 +3045,9 @@ proc de1_ble_handler { event data } {
 
 							} elseif {[info exists weightarray(weight)] == 1} {
 								set sensorweight [expr {$weightarray(weight) / 10.0}]
+								if {$weightarray(command) == 0xCE} {
+									::device::scale::watchdog_tickle $handle
+								}
 								::device::scale::process_weight_update $sensorweight $event_time
 							 	if {[info exists weightarray(timestamp)] == 1} {
 									set ::de1(scale_timestamp) $weightarray(timestamp)

--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -3045,9 +3045,7 @@ proc de1_ble_handler { event data } {
 
 							} elseif {[info exists weightarray(weight)] == 1} {
 								set sensorweight [expr {$weightarray(weight) / 10.0}]
-								if {$weightarray(command) == 0xCE} {
-									::device::scale::watchdog_tickle $handle
-								}
+								::device::scale::watchdog_tickle $handle $weightarray(command)
 								::device::scale::process_weight_update $sensorweight $event_time
 							 	if {[info exists weightarray(timestamp)] == 1} {
 									set ::de1(scale_timestamp) $weightarray(timestamp)

--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -3045,8 +3045,10 @@ proc de1_ble_handler { event data } {
 
 							} elseif {[info exists weightarray(weight)] == 1} {
 								set sensorweight [expr {$weightarray(weight) / 10.0}]
-								::device::scale::watchdog_tickle $handle $weightarray(command)
-								::device::scale::process_weight_update $sensorweight $event_time
+								if { ! [::device::scale::process_decentscale_weight_update \
+										$handle $weightarray(command) $sensorweight $event_time] } {
+									return
+								}
 							 	if {[info exists weightarray(timestamp)] == 1} {
 									set ::de1(scale_timestamp) $weightarray(timestamp)
 									#set ::de1(scale_minutes) $weightarray(minutes)

--- a/de1plus/de1_comms.tcl
+++ b/de1plus/de1_comms.tcl
@@ -585,6 +585,11 @@ proc de1_event_handler { command_name value {update_received 0}} {
 }
 
 proc scale_disconnect_handler { handle } {
+	if { ! [::device::scale::should_handle_disconnect $handle] } {
+		::bt::msg -DEBUG "Ignoring stale or duplicate scale disconnect for handle $handle"
+		return
+	}
+
 	catch {
 		ble close $handle
 	}

--- a/de1plus/de1_de1.tcl
+++ b/de1plus/de1_de1.tcl
@@ -830,7 +830,7 @@ namespace eval ::de1::sav {
 
 		::de1::state::reset_shotsample_tracking flow_start
 
-		if {$::de1(scale_device_handle) != 0} {
+		if {[::device::scale::is_operational]} {
 			msg -NOTICE "::de1::sav::start_active: disabled SAV because scale is connected"
 		}
 
@@ -873,7 +873,7 @@ namespace eval ::de1::sav {
 	proc on_hotwater_start {args} {
 
 		variable _target
-		if {$::de1(scale_device_handle) != 0} {
+		if {[::device::scale::is_operational]} {
 			# "hot water: stop on weight" feature. Works with the scale, so it's more accurate.
 			# we ask for more water than we need, so that we can definitely get enough
 			# to stop on weight.

--- a/de1plus/de1app-textmode.tcl
+++ b/de1plus/de1app-textmode.tcl
@@ -93,6 +93,16 @@ proc ::device::scale::process_weight_update {w {t 0}} {
     set ::de1(scale_weight) $w
     puts "    >>> SCALE WEIGHT: [format %.1f $w] g"
 }
+proc ::device::scale::process_decentscale_weight_update {handle command w {t 0}} {
+    if {$handle ne $::de1(scale_device_handle)} { return 0 }
+    ::device::scale::process_weight_update $w $t
+    return 1
+}
+proc ::device::scale::watchdog_tickle {args} {}
+proc ::device::scale::is_operational {} {
+    expr {$::de1(scale_device_handle) != 0}
+}
+proc ::device::scale::should_handle_disconnect {handle} { return 1 }
 proc ::device::scale::event::apply::on_connect_callbacks {args} {}
 proc ::device::scale::event::apply::on_disconnect_callbacks {args} {}
 namespace eval ::de1::state {}

--- a/de1plus/device_scale.tcl
+++ b/de1plus/device_scale.tcl
@@ -345,6 +345,17 @@ namespace eval ::device::scale {
 		::device::scale::event::apply::on_update_available_callbacks $event_dict
 	}
 
+	proc process_decentscale_weight_update {handle command reported_weight event_time} {
+		if { $handle != $::de1(scale_device_handle) } {
+			msg -DEBUG "Ignoring weight packet from stale scale handle $handle"
+			return False
+		}
+
+		::device::scale::watchdog_tickle $handle $command
+		::device::scale::process_weight_update $reported_weight $event_time
+		return True
+	}
+
 
 	proc tare {args} {
 

--- a/de1plus/device_scale.tcl
+++ b/de1plus/device_scale.tcl
@@ -101,6 +101,7 @@ namespace eval ::device::scale {
 
 	variable _watchdog_id ""
 	variable _watchdog_updates_seen False
+	variable _handled_disconnect_handle ""
 
 	variable _tare_last_requested 0
 
@@ -133,6 +134,26 @@ namespace eval ::device::scale {
 
 	proc is_operational {} {
 		expr { [::device::scale::is_connected] && $::device::scale::_watchdog_updates_seen }
+	}
+
+	proc should_handle_disconnect {handle} {
+		set active_handle 0
+		set connecting_handle 0
+		if { [info exists ::de1(scale_device_handle)] } {
+			set active_handle $::de1(scale_device_handle)
+		}
+		if { [info exists ::currently_connecting_scale_handle] } {
+			set connecting_handle $::currently_connecting_scale_handle
+		}
+
+		if { $handle == $::device::scale::_handled_disconnect_handle \
+				|| ($active_handle != 0 && $handle != $active_handle) \
+				|| ($active_handle == 0 && $connecting_handle != 0 && $handle != $connecting_handle) } {
+			return False
+		}
+
+		set ::device::scale::_handled_disconnect_handle $handle
+		return True
 	}
 
 	proc bluetooth_address {}  {
@@ -445,7 +466,11 @@ namespace eval ::device::scale {
 		}
 	}
 
-	proc watchdog_tickle {{handle ""}} {
+	proc watchdog_tickle {{handle ""} {command ""}} {
+
+		if { $command != "" && $command != 0xCE } {
+			return
+		}
 
 		if { $handle != "" && $handle != $::de1(scale_device_handle) } {
 			msg -DEBUG "Ignoring scale update for stale handle $handle"
@@ -459,6 +484,9 @@ namespace eval ::device::scale {
 
 		    set ::device::scale::_watchdog_updates_seen True
 		    set ::blink_water_weight 0
+		    if { [info commands de1_send_steam_hotwater_settings] != "" } {
+			    after 0 de1_send_steam_hotwater_settings
+		    }
 
 		}
 
@@ -1216,6 +1244,10 @@ namespace eval ::device::scale::saw {
 		variable _ignore_first_seconds
 		variable _mode_timer
 
+		if { ! [::device::scale::is_operational] } {
+			return
+		}
+
 		unset -nocomplain thisadvstep
 
 		array set thisadvstep \
@@ -1369,7 +1401,7 @@ namespace eval ::device::scale::saw {
 		variable _ignore_first_seconds
 		variable _mode_timer
 
-		if { $::settings(water_stop_on_scale) } {
+		if { $::settings(water_stop_on_scale) && [::device::scale::is_operational] } {
 			set _target $::settings(water_volume)
 		} else {
 			set _target 0
@@ -1464,6 +1496,7 @@ namespace eval ::device::scale::callbacks {
 
 		::device::scale::_watchdog_cancel
 		set ::device::scale::_watchdog_updates_seen False
+		set ::device::scale::_handled_disconnect_handle ""
 		::device::scale::watchdog_first
 
 		set ::device::scale::run_timer	    False

--- a/de1plus/device_scale.tcl
+++ b/de1plus/device_scale.tcl
@@ -131,6 +131,10 @@ namespace eval ::device::scale {
 		expr { [info exists ::de1(scale_device_handle)] == 1  &&  $::de1(scale_device_handle) != 0 }
 	}
 
+	proc is_operational {} {
+		expr { [::device::scale::is_connected] && $::device::scale::_watchdog_updates_seen }
+	}
+
 	proc bluetooth_address {}  {
 		expr { $::settings(scale_bluetooth_address) }
 	}
@@ -194,7 +198,9 @@ namespace eval ::device::scale {
 
 		if { $event_time == 0 } {set event_time [expr { [clock milliseconds] / 1000.0 }]}
 
-		::device::scale::watchdog_tickle
+		if { $::settings(scale_type) != "decentscale" } {
+			::device::scale::watchdog_tickle
+		}
 
 		if { [expr { abs($reported_weight) < $::device::scale::tare_threshold }] \
 			     && $::device::scale::_tare_awaiting_zero  \
@@ -404,13 +410,19 @@ namespace eval ::device::scale {
 		} else {
 			after cancel $::device::scale::_watchdog_id
 		}
+		set handle $::de1(scale_device_handle)
 		set ::device::scale::_watchdog_id \
 			[ after $::device::scale::_watchdog_timeout \
-				  [list ::device::scale::_watchdog_first_fire 1] ]
+				  [list ::device::scale::_watchdog_first_fire $handle 1] ]
 
 	}
 
-	proc _watchdog_first_fire {tries} {
+	proc _watchdog_first_fire {handle tries} {
+
+		if { ! [::device::scale::is_connected] || $handle != $::de1(scale_device_handle) } {
+			msg -DEBUG "Ignoring stale scale watchdog for handle $handle"
+			return
+		}
 
 		if { $tries >=	${::device::scale::_watchdog_update_tries} } {
 		    msg -ERROR "Scale updates not seen, $tries of" \
@@ -418,6 +430,7 @@ namespace eval ::device::scale {
 
 			::gui::notify::scale_event abandoning_updates
 			::device::scale::_watchdog_cancel
+			scale_disconnect_handler $handle
 		} else {
 		    msg -WARNING "Scale updates not seen, $tries of" \
 			    "${::device::scale::_watchdog_update_tries}"
@@ -428,11 +441,16 @@ namespace eval ::device::scale {
 
 			set ::device::scale::_watchdog_id \
 				[ after $::device::scale::_watchdog_timeout \
-					  [list ::device::scale::_watchdog_first_fire [incr tries]] ]
+					  [list ::device::scale::_watchdog_first_fire $handle [incr tries]] ]
 		}
 	}
 
-	proc watchdog_tickle {} {
+	proc watchdog_tickle {{handle ""}} {
+
+		if { $handle != "" && $handle != $::de1(scale_device_handle) } {
+			msg -DEBUG "Ignoring scale update for stale handle $handle"
+			return
+		}
 
 		if { ! $::device::scale::_watchdog_updates_seen } {
 
@@ -440,6 +458,7 @@ namespace eval ::device::scale {
 		    ::gui::notify::scale_event scale_reporting
 
 		    set ::device::scale::_watchdog_updates_seen True
+		    set ::blink_water_weight 0
 
 		}
 
@@ -1443,8 +1462,8 @@ namespace eval ::device::scale::callbacks {
 
 		::device::scale::init
 
+		::device::scale::_watchdog_cancel
 		set ::device::scale::_watchdog_updates_seen False
-		set ::device::scale::_watchdog_id ""
 		::device::scale::watchdog_first
 
 		set ::device::scale::run_timer	    False

--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -955,7 +955,7 @@ proc espresso_simulation_active {} {
 
 proc start_espresso {} {
 
-	if {$::settings(start_espresso_only_if_scale_connected) == 1 && $::de1(scale_device_handle) == 0 && $::settings(scale_bluetooth_address) != ""} {
+	if {$::settings(start_espresso_only_if_scale_connected) == 1 && ! [::device::scale::is_operational] && $::settings(scale_bluetooth_address) != ""} {
 		msg -WARNING "Refusing to START espresso without the scale being connected"
 		info_page [translate "Please connect your scale"] [translate "Ok"]
 		return

--- a/de1plus/skins/Streamline/skin.tcl
+++ b/de1plus/skins/Streamline/skin.tcl
@@ -701,9 +701,11 @@ proc streamline_ui_weight_refresh {} {
 proc scale_tare_or_reconnect {} {
 	say [translate {Tare}] $::settings(sound_button_out); 
 
-	if {$::de1(scale_device_handle) != 0} {
+	if {[::device::scale::is_operational]} {
 		::device::scale::tare; 
 		popup [translate Tare]
+	} elseif {[::device::scale::is_connected]} {
+		scale_disconnect_handler $::de1(scale_device_handle)
 	} else {
 		if {$::currently_connecting_scale_handle == 0} {
 			set ::de1(bluetooth_scale_connection_attempts_tried) 0

--- a/de1plus/skins/Streamline/skin.tcl
+++ b/de1plus/skins/Streamline/skin.tcl
@@ -673,7 +673,7 @@ set ::streamline_dataline_weight_label_red ""
 set ::streamline_dataline_weight_value ""
 set ::streamline_dataline_weight_unit ""
 proc streamline_ui_weight_refresh {} {
-	if {$::de1(scale_device_handle) != 0} {
+	if {[::device::scale::is_operational]} {
 		set ::streamline_dataline_weight_label_blue [translate "Weight"]
 		set ::streamline_dataline_weight_label_red ""
 		set ::streamline_dataline_weight_value [lindex [return_weight_measurement_grams $::de1(scale_sensor_weight) 0 1] 0]
@@ -687,7 +687,7 @@ proc streamline_ui_weight_refresh {} {
 		#set ::streamline_dataline_weight_label_blue [translate "Weight: !!"]
 		#set ::streamline_dataline_weight_label_blue [translate "Weight: ..."]
 		set ::streamline_dataline_weight_label_red "[translate Weight:] !! "
-		if {$::currently_connecting_scale_handle == 0} {
+		if {$::de1(scale_device_handle) == 0 && $::currently_connecting_scale_handle == 0} {
 			set ::streamline_dataline_weight_label_blue " [translate \[Reconnect\]]"
 		} else {
 			set ::streamline_dataline_weight_label_blue " [translate Wait]"

--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -1238,6 +1238,9 @@ proc waterweight_text {} {
 	if {$::de1(scale_weight) == "" || [ifexists ::settings(scale_bluetooth_address)] == ""} {
 		return ""
 	}
+	if { ! [::device::scale::is_operational] } {
+		return ""
+	}
 
 	if {!$::has_bluetooth} {
 		if {[espresso_millitimer] < 5000} {	
@@ -1271,6 +1274,9 @@ proc waterweight_text {} {
 proc waterweight_label_text {} {
 	if {[ifexists ::settings(scale_bluetooth_address)] == ""} {
 		return ""
+	}
+	if { [::device::scale::is_connected] && ! [::device::scale::is_operational] } {
+		return [translate "Wait"]
 	}
 
 	if {$::de1(scale_device_handle) == "0"} {

--- a/tests/scale_watchdog.test.tcl
+++ b/tests/scale_watchdog.test.tcl
@@ -1,0 +1,81 @@
+package require tcltest
+namespace import ::tcltest::*
+
+foreach {package version} {
+	de1_de1 1.1
+	de1_event 1.0
+	de1_logging 1.0
+	de1_gui 1.3
+} {
+	package provide $package $version
+}
+
+namespace eval ::de1::event::listener {
+	proc on_major_state_change_add {args} {}
+	proc after_flow_complete_add {args} {}
+	proc on_flow_change_add {args} {}
+}
+
+namespace eval ::event::listener {
+	proc _init_callback_list {args} {}
+	proc _generic_add {args} {}
+}
+
+namespace eval ::gui::notify {
+	proc scale_event {event args} {
+		lappend ::scale_events $event
+	}
+}
+
+proc msg {args} {}
+proc scale_enable_weight_notifications {} {}
+proc ble_connect_to_scale {} {
+	incr ::reconnects
+}
+proc scale_disconnect_handler {handle} {
+	lappend ::closed_handles $handle
+	set ::de1(scale_device_handle) 0
+	ble_connect_to_scale
+}
+
+source [file join [file dirname [info script]] .. de1plus device_scale.tcl]
+
+rename after tcl_after
+proc after {args} {
+	if {[lindex $args 0] eq "cancel"} {
+		lappend ::cancelled [lindex $args 1]
+		return
+	}
+	return watchdog-next
+}
+
+proc reset_watchdog {handle} {
+	set ::de1(scale_device_handle) $handle
+	set ::device::scale::_watchdog_id watchdog-current
+	set ::device::scale::_watchdog_updates_seen False
+	set ::closed_handles {}
+	set ::cancelled {}
+	set ::scale_events {}
+	set ::reconnects 0
+	set ::blink_water_weight 1
+}
+
+test scale-watchdog-exhaustion-1 {} -body {
+	reset_watchdog ble1
+	::device::scale::_watchdog_first_fire ble1 10
+	list $::closed_handles $::reconnects $::de1(scale_device_handle)
+} -result {ble1 1 0}
+
+test scale-watchdog-stale-handle-1 {} -body {
+	reset_watchdog ble2
+	::device::scale::_watchdog_first_fire ble1 10
+	list $::closed_handles $::reconnects $::de1(scale_device_handle)
+} -result {{} 0 ble2}
+
+test scale-first-live-weight-1 {} -body {
+	reset_watchdog ble1
+	::device::scale::watchdog_tickle ble1
+	list $::device::scale::_watchdog_updates_seen $::blink_water_weight $::scale_events $::cancelled
+} -result {True 0 scale_reporting watchdog-current}
+
+cleanupTests

--- a/tests/scale_watchdog.test.tcl
+++ b/tests/scale_watchdog.test.tcl
@@ -4,8 +4,9 @@ namespace import ::tcltest::*
 foreach {package version} {
 	de1_de1 1.1
 	de1_event 1.0
-	de1_logging 1.0
+	de1_logging 1.2
 	de1_gui 1.3
+	de1_bluetooth 1.0
 } {
 	package provide $package $version
 }
@@ -27,18 +28,24 @@ namespace eval ::gui::notify {
 	}
 }
 
+namespace eval ::bt {
+	proc msg {args} {}
+}
+
 proc msg {args} {}
 proc scale_enable_weight_notifications {} {}
+proc ble {command handle} {
+	if {$command eq "close" && $handle != 0} {
+		lappend ::closed_handles $handle
+	}
+}
 proc ble_connect_to_scale {} {
 	incr ::reconnects
-}
-proc scale_disconnect_handler {handle} {
-	lappend ::closed_handles $handle
-	set ::de1(scale_device_handle) 0
-	ble_connect_to_scale
+	set ::currently_connecting_scale_handle ble2
 }
 
 source [file join [file dirname [info script]] .. de1plus device_scale.tcl]
+source [file join [file dirname [info script]] .. de1plus de1_comms.tcl]
 
 rename after tcl_after
 proc after {args} {
@@ -53,18 +60,22 @@ proc reset_watchdog {handle} {
 	set ::de1(scale_device_handle) $handle
 	set ::device::scale::_watchdog_id watchdog-current
 	set ::device::scale::_watchdog_updates_seen False
+	set ::device::scale::_handled_disconnect_handle ""
 	set ::closed_handles {}
 	set ::cancelled {}
 	set ::scale_events {}
 	set ::reconnects 0
 	set ::blink_water_weight 1
+	set ::currently_connecting_scale_handle 0
+	set ::de1(bluetooth_scale_connection_attempts_tried) 0
+	set ::de1(scale_max_connection_retry_attempts) 10
 }
 
 test scale-watchdog-exhaustion-1 {} -body {
 	reset_watchdog ble1
 	::device::scale::_watchdog_first_fire ble1 10
-	list $::closed_handles $::reconnects $::de1(scale_device_handle)
-} -result {ble1 1 0}
+	list $::closed_handles $::reconnects $::de1(scale_device_handle) $::currently_connecting_scale_handle
+} -result {ble1 1 0 ble2}
 
 test scale-watchdog-stale-handle-1 {} -body {
 	reset_watchdog ble2
@@ -72,9 +83,50 @@ test scale-watchdog-stale-handle-1 {} -body {
 	list $::closed_handles $::reconnects $::de1(scale_device_handle)
 } -result {{} 0 ble2}
 
+test scale-disconnect-late-callback-1 {} -body {
+	reset_watchdog ble1
+	::device::scale::_watchdog_first_fire ble1 10
+	scale_disconnect_handler ble1
+	list $::closed_handles $::reconnects $::currently_connecting_scale_handle
+} -result {ble1 1 ble2}
+
+test scale-disconnect-late-connected-callback-1 {} -body {
+	reset_watchdog ble1
+	::device::scale::_watchdog_first_fire ble1 10
+	set ::de1(scale_device_handle) ble2
+	set ::currently_connecting_scale_handle 0
+	scale_disconnect_handler ble1
+	list $::closed_handles $::reconnects $::de1(scale_device_handle)
+} -result {ble1 1 ble2}
+
+test scale-disconnect-stale-active-handle-1 {} -body {
+	reset_watchdog ble2
+	scale_disconnect_handler ble1
+	list $::closed_handles $::reconnects $::de1(scale_device_handle)
+} -result {{} 0 ble2}
+
+test scale-disconnect-stale-connecting-handle-1 {} -body {
+	reset_watchdog 0
+	set ::currently_connecting_scale_handle ble2
+	scale_disconnect_handler ble1
+	list $::closed_handles $::reconnects $::currently_connecting_scale_handle
+} -result {{} 0 ble2}
+
+test scale-cached-weight-1 {} -body {
+	reset_watchdog ble1
+	::device::scale::watchdog_tickle ble1 0xCA
+	list $::device::scale::_watchdog_updates_seen $::cancelled
+} -result {False {}}
+
+test scale-stale-live-weight-1 {} -body {
+	reset_watchdog ble1
+	::device::scale::watchdog_tickle ble2 0xCE
+	list $::device::scale::_watchdog_updates_seen $::cancelled
+} -result {False {}}
+
 test scale-first-live-weight-1 {} -body {
 	reset_watchdog ble1
-	::device::scale::watchdog_tickle ble1
+	::device::scale::watchdog_tickle ble1 0xCE
 	list $::device::scale::_watchdog_updates_seen $::blink_water_weight $::scale_events $::cancelled
 } -result {True 0 scale_reporting watchdog-current}
 

--- a/tests/scale_watchdog.test.tcl
+++ b/tests/scale_watchdog.test.tcl
@@ -47,6 +47,11 @@ proc ble_connect_to_scale {} {
 source [file join [file dirname [info script]] .. de1plus device_scale.tcl]
 source [file join [file dirname [info script]] .. de1plus de1_comms.tcl]
 
+rename ::device::scale::process_weight_update ::device::scale::process_weight_update_real
+proc ::device::scale::process_weight_update {weight {event_time 0}} {
+	lappend ::processed_weights [list $weight $event_time]
+}
+
 rename after tcl_after
 proc after {args} {
 	if {[lindex $args 0] eq "cancel"} {
@@ -69,6 +74,7 @@ proc reset_watchdog {handle} {
 	set ::currently_connecting_scale_handle 0
 	set ::de1(bluetooth_scale_connection_attempts_tried) 0
 	set ::de1(scale_max_connection_retry_attempts) 10
+	set ::processed_weights {}
 }
 
 test scale-watchdog-exhaustion-1 {} -body {
@@ -114,20 +120,20 @@ test scale-disconnect-stale-connecting-handle-1 {} -body {
 
 test scale-cached-weight-1 {} -body {
 	reset_watchdog ble1
-	::device::scale::watchdog_tickle ble1 0xCA
-	list $::device::scale::_watchdog_updates_seen $::cancelled
-} -result {False {}}
+	set accepted [::device::scale::process_decentscale_weight_update ble1 0xCA 1.2 3.4]
+	list $accepted $::processed_weights $::device::scale::_watchdog_updates_seen
+} -result {True {{1.2 3.4}} False}
 
 test scale-stale-live-weight-1 {} -body {
 	reset_watchdog ble1
-	::device::scale::watchdog_tickle ble2 0xCE
-	list $::device::scale::_watchdog_updates_seen $::cancelled
-} -result {False {}}
+	set accepted [::device::scale::process_decentscale_weight_update ble2 0xCE 1.2 3.4]
+	list $accepted $::processed_weights $::device::scale::_watchdog_updates_seen
+} -result {False {} False}
 
 test scale-first-live-weight-1 {} -body {
 	reset_watchdog ble1
-	::device::scale::watchdog_tickle ble1 0xCE
-	list $::device::scale::_watchdog_updates_seen $::blink_water_weight $::scale_events $::cancelled
-} -result {True 0 scale_reporting watchdog-current}
+	set accepted [::device::scale::process_decentscale_weight_update ble1 0xCE 1.2 3.4]
+	list $accepted $::processed_weights $::device::scale::_watchdog_updates_seen $::blink_water_weight $::scale_events $::cancelled
+} -result {True {{1.2 3.4}} True 0 scale_reporting watchdog-current}
 
 cleanupTests


### PR DESCRIPTION
## Failure sequence

DE1app retained an HDS BLE handle whose control writes still succeeded, including heartbeats, tare, and timer commands, but no FFF4 `0xCE` weight notifications arrived. The first-update watchdog retried notification enable ten times, abandoned recovery, and left the stale handle connected. Power cycling and reconnecting restored weight updates, while the UI could continue to show `WEIGHT WAIT`.

## Root cause

The first-update watchdog was not tied to the handle it watched and only cancelled itself after retry exhaustion. Disconnect cleanup was also not idempotent or handle-aware, so a delayed disconnect callback for the stale handle could clear or close a replacement connection. Weight packets were likewise processed without verifying that they belonged to the active handle. Scale-dependent controls and the weight UI used the BLE connection handle rather than confirmed live weight reporting.

## Behavior change

- Capture and verify the active scale handle in the first-update watchdog.
- On retry exhaustion, route the same stale handle through the existing scale disconnect cleanup and automatic reconnect path.
- Ignore duplicate disconnects and callbacks for stale handles while a replacement is connecting or active.
- Reject stale-handle weight packets before history, timestamps, displayed weight, or stop-at-weight processing.
- Mark a Decent Scale operational only after a live FFF4 `0xCE` weight packet from the active handle.
- Keep connection acknowledgements, LED/status packets, command acknowledgements, and cached `0xCA` weights from clearing the wait state.
- Use operational state for hot-water volume fallback, SAV/SAW readiness, optional scale-required espresso starts, and the Streamline tare/reconnect action.
- Resend the existing hot-water settings when live reporting is first confirmed.
- Keep the text-mode harness compatible with the new scale state API.

## Tests

- `C:\Program Files\Git\mingw64in	clsh.exe tests\scale_watchdog.test.tcl` (9 passed)
- `git diff --check`
- `de1app-textmode.tcl` startup reached the REPL and exited cleanly; the local environment still reports its pre-existing missing `lambda` and `ble` packages.

Coverage includes retry exhaustion, stale watchdog handles, duplicate disconnect callbacks, stale disconnects while a replacement is connecting or connected, cached `0xCA` processing without operational state, active-handle `0xCE` processing, and stale-handle `0xCE` rejection before `process_weight_update`. The disconnect cases exercise the real `scale_disconnect_handler`; packet tests record weight-processing calls.
