### PR TITLE
Retire obsolete Decent Scale Off plugin

### DIFF
--- a/de1plus/plugins.tcl
+++ b/de1plus/plugins.tcl
@@ -197,6 +197,8 @@ namespace eval ::plugins {
             if {[string tolower $fbasename] == "dpx_steam_stop"} {
                 # incommpatible with firmware v1330 and newer because this functionality is already in the firmware, so plugin not needed
                 continue
+            } elseif {[string tolower $fbasename] == "decentscale_off"} {
+                continue
             } elseif {[string tolower $fbasename] == "skip_first_step_notice"} {
                 # per Damian's suggestion, should not be part of STABLE
                 continue

--- a/de1plus/plugins/decentscale_off/plugin.tcl
+++ b/de1plus/plugins/decentscale_off/plugin.tcl
@@ -1,43 +1,9 @@
-package require de1_bluetooth 1.1
-
 set plugin_name "decentscale_off"
-
 
 namespace eval ::plugins::${plugin_name} {
     variable author "Martin D"
     variable contact "Via Diaspora"
-    variable version 1.0
+    variable version 1.1
     variable name "Decent Scale Off"
-    variable description "Turn battery-powered Decent Scale off when DE1 sleeps. Requires Decent Scale v1.2 or newer."
-
-    proc decentscale_disable_lcd {} {
-	    if {$::de1(scale_device_handle) == 0 || $::settings(scale_type) != "decentscale"} {
-		    return
-	    }
-	    set scaleoff [decent_scale_make_command 0A 02 00]
-
-	    if {[ifexists ::sinstance($::de1(suuid_decentscale))] == ""} {
-		    ::bt::msg -DEBUG "decentscale not connected, cannot sleep scale"
-		    return
-	    }
-
-	    userdata_append "SCALE: decentscale : sleep" [list ble write $::de1(scale_device_handle) $::de1(suuid_decentscale) $::sinstance($::de1(suuid_decentscale)) $::de1(cuuid_decentscale_write) $::cinstance($::de1(cuuid_decentscale_write)) $scaleoff] 0
-    }
-
-    proc main {} {
-        proc ::scale_disable_lcd {} {
-            msg "Scale Sleep for Power from Battery"
-
-            ::bt::msg -NOTICE scale_sleep
-            if {$::settings(scale_type) == "decentscale"} {
-                if {$::de1(scale_usb_powered) == 0} {
-                    after 3000 ::plugins::decentscale_off::decentscale_disable_lcd
-                } else {
-                    decentscale_disable_lcd
-                }
-            }
-        }
-    }
+    variable description "Retired: Decent Scale power-off is built into the app."
 }
-
-

--- a/de1plus/utils.tcl
+++ b/de1plus/utils.tcl
@@ -1310,6 +1310,25 @@ proc save_settings {} {
     #de1_read_hotwater
 }
 
+proc remove_retired_plugins_from_settings {} {
+	set enabled_plugins $::settings(enabled_plugins)
+	foreach retired_plugin {
+		DPx_Flow_Calibrator
+		dpx_steam_stop
+		skip_first_step_notice
+		decentscale_off
+	} {
+		set enabled_plugins [lsearch -all -inline -not -exact $enabled_plugins $retired_plugin]
+	}
+
+	if {$enabled_plugins eq $::settings(enabled_plugins)} {
+		return 0
+	}
+
+	set ::settings(enabled_plugins) $enabled_plugins
+	return 1
+}
+
 proc load_settings {} {
 
 
@@ -1416,10 +1435,7 @@ proc load_settings {} {
     }
 
 
-    # remove no-longer-supported extensions from settings
-	set ::settings(enabled_plugins) [lsearch -all -inline -not -exact $::settings(enabled_plugins) "DPx_Flow_Calibrator"]
-	set ::settings(enabled_plugins) [lsearch -all -inline -not -exact $::settings(enabled_plugins) "dpx_steam_stop"]
-	set ::settings(enabled_plugins) [lsearch -all -inline -not -exact $::settings(enabled_plugins) "skip_first_step_notice"]
+	set retired_plugins_removed [remove_retired_plugins_from_settings]
 
     #set ::de1(language_rtl) 1
     
@@ -1484,7 +1500,10 @@ proc load_settings {} {
 
     #espresso_temperature_goal append [expr {$::settings(espresso_temperature) - 5}]
     #espresso_elapsed append 0    
-    clear_espresso_chart
+	clear_espresso_chart
+	if {$retired_plugins_removed} {
+		save_settings
+	}
 }
 
 proc skin_xscale_factor {} {

--- a/tests/decentscale_off.test.tcl
+++ b/tests/decentscale_off.test.tcl
@@ -2,6 +2,8 @@ package require tcltest
 namespace import ::tcltest::*
 
 package provide de1_logging 1.1
+package provide de1_metadata 1.0
+package provide struct::set 1.0
 
 set test_root [file normalize [file join [file dirname [info script]] .. de1plus]]
 
@@ -15,6 +17,7 @@ proc scale_disable_lcd {} {
 
 source [file join [file dirname [info script]] .. de1plus plugins.tcl]
 source [file join [file dirname [info script]] .. de1plus plugins decentscale_off plugin.tcl]
+source [file join [file dirname [info script]] .. de1plus utils.tcl]
 
 test decentscale-off-does-not-override-core-1 {} -body {
 	if {[info commands ::plugins::decentscale_off::main] ne ""} {
@@ -27,10 +30,11 @@ test decentscale-off-is-hidden-1 {} -body {
 	expr {[lsearch -exact [plugins list] decentscale_off] < 0}
 } -result 1
 
-test decentscale-off-stale-enabled-entry-1 {} -body {
-	set ::settings(enabled_plugins) {decentscale_off}
-	plugins load decentscale_off
-	plugins loaded decentscale_off
-} -result 0
+test decentscale-off-stale-enabled-entry-is-migrated-1 {} -body {
+	set ::settings(enabled_plugins) {visualizer_upload decentscale_off}
+	set migrated [remove_retired_plugins_from_settings]
+	set unchanged [remove_retired_plugins_from_settings]
+	list $migrated $unchanged [plugins enabled decentscale_off] $::settings(enabled_plugins)
+} -result {1 0 false visualizer_upload}
 
 cleanupTests

--- a/tests/decentscale_off.test.tcl
+++ b/tests/decentscale_off.test.tcl
@@ -1,0 +1,36 @@
+package require tcltest
+namespace import ::tcltest::*
+
+package provide de1_logging 1.1
+
+set test_root [file normalize [file join [file dirname [info script]] .. de1plus]]
+
+proc msg {args} {}
+proc homedir {} {
+	return $::test_root
+}
+proc scale_disable_lcd {} {
+	return core
+}
+
+source [file join [file dirname [info script]] .. de1plus plugins.tcl]
+source [file join [file dirname [info script]] .. de1plus plugins decentscale_off plugin.tcl]
+
+test decentscale-off-does-not-override-core-1 {} -body {
+	if {[info commands ::plugins::decentscale_off::main] ne ""} {
+		::plugins::decentscale_off::main
+	}
+	scale_disable_lcd
+} -result core
+
+test decentscale-off-is-hidden-1 {} -body {
+	expr {[lsearch -exact [plugins list] decentscale_off] < 0}
+} -result 1
+
+test decentscale-off-stale-enabled-entry-1 {} -body {
+	set ::settings(enabled_plugins) {decentscale_off}
+	plugins load decentscale_off
+	plugins loaded decentscale_off
+} -result 0
+
+cleanupTests


### PR DESCRIPTION
## Summary

- retire `Decent Scale Off` as an inert compatibility shim
- hide the obsolete plugin from the plugin list
- migrate persisted `decentscale_off` enablement out of settings
- add regression coverage for the shim, visibility, and migration

## Root cause

The plugin replaced the core `scale_disable_lcd` procedure and delayed the scale power-off write by three seconds. The normal sleep path disconnects the scale after one second, so the connection could close before the plugin sent the command. Core app code now owns this behavior and queues power-off before disconnecting.

## Impact

Existing installations receive the inert shim through the updater, while new users cannot enable the obsolete plugin. Persisted enablement is removed and saved once, preventing an older plugin copy from reactivating after a channel downgrade. The core `keep_scale_on` behavior remains unchanged.

## Validation

- `tests/decentscale_off.test.tcl`: 3 passed
- migration removes only known retired plugins and is idempotent
- `git diff --check`
- verified the core sleep path orders `scale_disable_lcd` before the delayed disconnect
- hardware validation not run