### PR TITLE
Fix three defects in fixed-point encoding and v2 JSON export

### DIFF
--- a/de1plus/binary.tcl
+++ b/de1plus/binary.tcl
@@ -510,15 +510,21 @@ proc make_packed_shot_sample {arrname} {
 }
 
 proc convert_float_to_U8P4 {in} {
-	if {$in > 16} {
-		set in 16
+	# 15.9375 is 255/16, the largest value this format holds. Clamping at 16
+	# yields 256, which does not fit the byte and truncates to 0 -- so a flow
+	# or pressure command of 16 or more encoded as ZERO.
+	if {$in > 15.9375} {
+		set in 15.9375
 	}
 	return [expr {round($in * 16)}]
 }
 
 proc convert_float_to_U8P1 {in} {
-	if {$in > 128} {
-		set in 128
+	# Same defect as convert_float_to_U8P4 above: 127.5 is 255/2, and clamping
+	# at 128 yields 256, which truncates to 0. A temperature of 128 C or more
+	# encoded as 0 C.
+	if {$in > 127.5} {
+		set in 127.5
 	}
 	return [expr {round($in * 2)}]
 }
@@ -608,7 +614,7 @@ proc make_shot_flag {enabled_features} {
 		} elseif {$feature == "IgnoreLimit"} {
 			set num [expr {$num | 0x40}]
 		} else {
-			err "unknown shot flat: '$feature'"
+			error "unknown shot flag: '$feature'"
 		}
 	}
 	return $num

--- a/de1plus/profile.tcl
+++ b/de1plus/profile.tcl
@@ -416,6 +416,10 @@ namespace eval ::profile {
             ]
             
             if {[ifexists props(exit_if)] == 1} {
+                # Cleared before the chain below: an unrecognised or missing
+                # exit_type would otherwise leave these three holding the
+                # PREVIOUS step's values, and write that stale triple here.
+                set exit_type ""
                 if {[ifexists props(exit_type)] == "pressure_under"} {
                     set exit_type "pressure"
                     set exit_condition "under"
@@ -433,7 +437,9 @@ namespace eval ::profile {
                     set exit_condition "over"
                     set exit_value $props(exit_flow_over)
                 }
-                huddle append huddle_step exit [huddle create type $exit_type condition $exit_condition value $exit_value]
+                if {$exit_type ne ""} {
+                    huddle append huddle_step exit [huddle create type $exit_type condition $exit_condition value $exit_value]
+                }
             }
             if {[ifexists props(max_flow_or_pressure)] >= 0 && [info exists props(max_flow_or_pressure_range)]} {
                 huddle append huddle_step limiter [huddle create value $props(max_flow_or_pressure) range $props(max_flow_or_pressure_range)]
@@ -909,6 +915,11 @@ namespace eval ::profile {
         set uses_limiters 0
 		
         foreach stepl $profile(advanced_shot) {
+            # Every profile step is an independent record. Tcl reuses this local
+            # array across iterations and [array set] merges rather than
+            # replaces, so an omitted optional key would otherwise inherit the
+            # preceding step's value.
+            unset -nocomplain step
             array set step $stepl
             if { $is_basic_profile } {
                 # Ignore the 2 seconds temperature ramp-up added when per-step temperatures are enabled 


### PR DESCRIPTION

## Summary

Three independent defects in `binary.tcl` and `profile.tcl`. None is specific to any
machine and none needs new hardware to reproduce. They are separated from a larger
Bengle series so they can be reviewed on their own merit.

All three were confirmed by running the code in `tclsh`, not by reading alone.

## 1. Two fixed-point converters overflow the byte they write

```tcl
proc convert_float_to_U8P4 {in} {
    if {$in > 16} { set in 16 }      ;# 16 * 16 = 256
    return [expr {round($in * 16)}]
}
proc convert_float_to_U8P1 {in} {
    if {$in > 128} { set in 128 }    ;# 128 * 2 = 256
    return [expr {round($in * 2)}]
}
```

Both clamp one step too high. The formats hold 255/16 = **15.9375** and 255/2 =
**127.5**. `binary format c 256` scans back as **0**, so:

- a flow or pressure command of 16 or more encodes as **zero flow**
- a temperature of 128 °C or more encodes as **0 °C**

Neither is reachable through the stock sliders, which stop below both limits. Both are
reachable through a hand-edited or imported profile.

## 2. `profile_steps_to_dict` leaks optional keys between steps

```tcl
foreach stepl $profile(advanced_shot) {
    array set step $stepl
```

Tcl reuses the local `step` array across iterations and `array set` merges rather than
replaces. The loop reads nine optional keys — `exit_if`, `exit_type`,
`exit_pressure_under`, `exit_pressure_over`, `exit_flow_under`, `exit_flow_over`,
`max_flow_or_pressure`, `volume`, `weight`. A step that omits one inherits the previous
step's value, so the explanation text describes a limiter or a "move on if" rule the
step does not have.

Fixed with `unset -nocomplain step`. The sibling loop in `legacy_profile_to_v2` already
does exactly this, so the two are now consistent.

## 3. v2 JSON export writes a stale exit condition

`legacy_profile_to_v2`'s `exit_if` chain has no `else`. A step with an unrecognised
`exit_type` keeps the previous step's `exit_type`, `exit_condition` and `exit_value` and
writes that stale triple into the exported profile. On the first step the variable is
undefined and the export throws `can't read "exit_type"`.

Fixed by clearing `exit_type` before the chain and appending only when a branch matched.

## Not changed

The neighbouring limiter guard looks like it has the same shape:

```tcl
if {[ifexists props(max_flow_or_pressure)] >= 0 && [info exists props(max_flow_or_pressure_range)]} {
```

It does not. `expr {"" >= 0}` is **false** in Tcl, so the guard already skips correctly
when the key is absent. Left alone.

## Test plan

Reproduced in `tclsh` before the fix and shown corrected after:

- [x] `convert_float_to_U8P4 16` returns 256; `binary format c 256` scans back as 0.
- [x] Two steps, the first with a limiter and the second without: the unfixed loop
      reports the limiter on both.
- [x] Two steps with `exit_if 1`, the second with an unrecognised `exit_type`: the
      unfixed chain writes the first step's exit condition onto the second.
- [x] One such step alone: the unfixed chain throws `can't read "exit_type"`.
- [ ] Save and reload a profile with differing limiter settings, in the app.
- [ ] Export a profile whose first step sets `exit_if 1` with an unknown `exit_type`.

## Testing

The ticked items ran in `tclsh` against reduced copies of the two loops. The unticked
ones need the app. There is no automated test coverage for these Tcl paths in the repo.
