### PR TITLE
Detect Bengle hardware from the model MMR and select the BLE protocol version

### DIFF
--- a/de1plus/bluetooth.tcl
+++ b/de1plus/bluetooth.tcl
@@ -2594,14 +2594,26 @@ proc de1_ble_handler { event data } {
 						::de1::event::apply::on_connect_callbacks \
 							[dict create event_time [expr {[clock milliseconds] / 1000.0}]]
 
+						# Look up the advertised name from the scan list. The list
+						# is runtime-only and empty on auto-reconnect (no fresh
+						# scan), so we only overwrite ::settings(model) when a
+						# real match is found. Otherwise whatever was persisted
+						# (e.g. "Bengle" from a prior scan) is preserved instead
+						# of being clobbered back to the default "DE1".
 						set espresso_machine_name "DE1"
+						set scan_name_found 0
 						foreach { entry } $::de1_device_list {
-							if { [dict get $entry address] eq $address} {								
+							if { [dict get $entry address] eq $address} {
 								set espresso_machine_name [dict get $entry name]
+								set scan_name_found 1
 								msg -INFO "Espresso machine model found: '$espresso_machine_name'"
 							}
 						}
-						set ::settings(model) $espresso_machine_name
+						if {$scan_name_found} {
+							set ::settings(model) $espresso_machine_name
+						} else {
+							msg -INFO "No scan entry for $address; preserving persisted model='[ifexists ::settings(model)]'"
+						}
 
 						de1_connect_handler $handle $address $espresso_machine_name
 

--- a/de1plus/de1_comms.tcl
+++ b/de1plus/de1_comms.tcl
@@ -2,6 +2,7 @@ package provide de1_comms 1.1
 
 package require de1_bluetooth
 package require de1_logging 1.2
+package require lambda
 
 ### Globals
 set ::failed_attempt_count_connecting_to_de1 0
@@ -17,6 +18,17 @@ proc long_to_little_endian_hex {in} {
 	set i [format %04X $in]
 	set i2 "[string range $i 2 3][string range $i 0 1]"
 	return $i2
+}
+
+# 4-byte little-endian hex for a 32-bit unsigned int. Companion to
+# long_to_little_endian_hex above (which only handles 16 bits despite the name).
+proc long32_to_little_endian_hex {val} {
+	set v [expr {$val & 0xFFFFFFFF}]
+	set b0 [expr {$v & 0xFF}]
+	set b1 [expr {($v >> 8) & 0xFF}]
+	set b2 [expr {($v >> 16) & 0xFF}]
+	set b3 [expr {($v >> 24) & 0xFF}]
+	return [format "%02X%02X%02X%02X" $b0 $b1 $b2 $b3]
 }
 
 # msg -DEBUG "::comms exists: [namespace exists ::comms]" (no)
@@ -219,15 +231,22 @@ proc de1_comm {action command_name {data 0}} {
 
 proc append_to_de1_list {address name type} {
 
+	# Replace any existing entry for the same address rather than
+	# early-returning -- the legacy "duplicate skip" behaviour caused
+	# stale names to persist across firmware swaps (e.g. the Bengle_BLE
+	# Mynewt port renamed the advertised device "DE1" -> "Bengle", but
+	# the list was seeded from settings.tdb at startup with the old
+	# name and the scan never overwrote it, so settings(model) stayed
+	# "DE1" -> use_ble_v2 returned false -> v1 protocol decoding was
+	# applied to v2-encoded ShotSample fields).
+	set newlist {}
 	foreach { entry } $::de1_device_list {
-		if { [dict get $entry address] eq $address} {
-			return
+		if { [dict get $entry address] ne $address} {
+			lappend newlist $entry
 		}
 	}
-
-	set newlist $::de1_device_list
 	lappend newlist [dict create address $address name $name type $type]
-	::comms::msg -NOTICE "Scan found DE1: $address"
+	::comms::msg -NOTICE "Scan found DE1: $address ($name)"
 	set ::de1_device_list $newlist
 	catch {
 		fill_ble_listbox
@@ -1720,8 +1739,13 @@ proc de1_read_shot_frame {} {
 }
 
 proc is_bengle_model {} {
-	if {$::settings(model) == "BENGLE"} {
-		return 1
-	}
-	return 0
+	# Delegate to the canonical Bengle detection used by the BLE packet
+	# code (shot sample decoder, shot profile encoder, max_flowrate). See
+	# ::de1::packet::detect_ble_protocol_version in de1_de1.tcl — it
+	# watches ::settings(machine_model) (set from the v13Model MMR) and
+	# flips ble_protocol_version to 2 when it equals 128. Reading the var
+	# directly (rather than calling use_ble_v2) avoids depending on the
+	# proc being defined at file-load time, which matters for the skin's
+	# is_bengle_model gates.
+	return [expr {[ifexists ::de1(ble_protocol_version) 1] >= 2}]
 }

--- a/de1plus/de1_de1.tcl
+++ b/de1plus/de1_de1.tcl
@@ -704,6 +704,65 @@ namespace eval ::de1::packet {
 	}
 
 
+	# ble_protocol_version 2 selects the Bengle wire formats:
+	#  - ShotSample (0xA00D) stays stock DE1 v1 (additive model).  The Bengle
+	#    high-resolution sample -- every scalar U16D2 (0.01 step) except Weight
+	#    (S16P4, SIGNED, 0.0625 g) and FrameNumber, plus integrated-scale GFlow and the
+	#    MilkTemp probe -- is carried on BengleShotSample (0xA013); see
+	#    bengleshotsample_parse.  On a Bengle the app charts from 0xA013 and
+	#    skips 0xA00D (the cuuid_0D dispatch is gated on use_ble_v2).
+	#  - HeaderWrite (0xA00F) / FrameWrite (0xA010): pressure/flow bytes become
+	#    U8D1 (0.1 step, max 25.5) instead of v1's U8P4, and HeaderV = 2.
+	# Together these raise the app's max_flowrate from 8 to 20 ml/s.
+	proc use_ble_v2 {} {
+		return [expr {[ifexists ::de1(ble_protocol_version) 1] >= 2}]
+	}
+
+	# Model 128 and above is Bengle hardware. It is a RANGE, not one value,
+	# so that later Bengle variants need no app change. This matches the
+	# isBengleModelValue rule already upstream in decentespresso/decaid.
+	proc is_bengle_model_value {m} {
+		if {![string is integer -strict $m]} { return 0 }
+		return [expr {$m >= 128}]
+	}
+
+	# Decides v1 vs v2 protocol from the machine_model MMR (v13Model at
+	# 0x0080000C). Authoritative — comes straight from the connected machine
+	# rather than the BLE-advertised name (which can be stale from a prior
+	# scan/persisted session).
+	proc detect_ble_protocol_version {} {
+		set m [ifexists ::settings(machine_model) ""]
+		if {$m eq ""} { return }
+		if {[::de1::packet::is_bengle_model_value $m]} {
+			::de1::packet::set_ble_protocol_version 2
+		} else {
+			::de1::packet::set_ble_protocol_version 1
+		}
+	}
+
+	proc set_ble_protocol_version {v} {
+		if {[ifexists ::de1(ble_protocol_version) 0] == $v} { return }
+		set ::de1(ble_protocol_version) $v
+		# max_flowrate_v11 is the live pump-flow ceiling: the default skin
+		# reads it for 16 slider/editor bounds, and vars.tcl range-checks
+		# against it. A Bengle raises it from 8 to 20 mL/s. The "_v11" name
+		# is upstream's and is now a misnomer; a rename would touch the
+		# default skin, so it is left for a separate change.
+		if {$v >= 2} {
+			set ::de1(max_flowrate_v11) 20
+		} else {
+			set ::de1(max_flowrate_v11) 8
+		}
+		::msg -INFO "BLE protocol version set to $v, max_flowrate_v11=$::de1(max_flowrate_v11)"
+	}
+
+	# Auto-run detection whenever ::settings(machine_model) is written. The
+	# MMR read in bluetooth.tcl / de1_comms.tcl assigns it on every connect,
+	# so one trace covers all reconnect paths and is robust against a stale
+	# persisted BLE-advertised name.
+	trace add variable ::settings(machine_model) write \
+		[list apply {{name1 name2 op} { ::de1::packet::detect_ble_protocol_version }}]
+
 	proc shotsample_parse {t_shotsample target_array_name} {
 
 		upvar $target_array_name ShotSample

--- a/de1plus/machine.tcl
+++ b/de1plus/machine.tcl
@@ -159,6 +159,7 @@ array set ::de1 {
 	max_pressure 12.0
 	max_flowrate 12.0
 	max_flowrate_v11 8
+	ble_protocol_version 1
 	version ""
 	min_temperature 80
 	max_temperature 100

--- a/de1plus/skins/default/de1_skin_settings.tcl
+++ b/de1plus/skins/default/de1_skin_settings.tcl
@@ -403,6 +403,12 @@ add_de1_widget "settings_2b" graph 24 220 {
 	$widget element create line_espresso_de1_explanation_chart_flow -xdata espresso_de1_explanation_chart_elapsed_flow -ydata espresso_de1_explanation_chart_flow -symbol circle -label "" -linewidth [rescale_x_skin 5] -color #888888  -smooth $::settings(profile_graph_smoothing_technique) -pixels [rescale_x_skin 30]; 
 	$widget axis configure x -color #5a5d75 -tickfont Helv_6 -command graph_seconds_axis_format; 
 	$widget axis configure y -color #5a5d75 -tickfont Helv_6 -min 0.0 -max 8.5 -majorticks {0 1 2 3 4 5 6 7 8} -title [translate "Flow rate"] -titlefont Helv_10 -titlecolor #5a5d75;
+	if {$::de1(max_flowrate_v11) >= 16} {
+		set _flow_ticks {0 4 8 12 16 20}
+	} else {
+		set _flow_ticks {0 1 2 3 4 5 6 7 8}
+	}
+	$widget axis configure y -color #5a5d75 -tickfont Helv_6 -min 0.0 -max [expr {$::de1(max_flowrate_v11) + 0.5}] -majorticks $_flow_ticks -title [translate "Flow rate"] -titlefont Helv_10 -titlecolor #5a5d75;
 	$widget element create line_espresso_de1_explanation_chart_flow_part1 -xdata espresso_de1_explanation_chart_elapsed_flow_1 -ydata espresso_de1_explanation_chart_flow_1 -symbol circle -label "" -linewidth [rescale_x_skin 50] -color $::settings(color_stage_1)  -smooth $::settings(profile_graph_smoothing_technique) -pixels [rescale_x_skin 30]; 
 	$widget element create line_espresso_de1_explanation_chart_flow_part2 -xdata espresso_de1_explanation_chart_elapsed_flow_2 -ydata espresso_de1_explanation_chart_flow_2 -symbol circle -label "" -linewidth [rescale_x_skin 50] -color $::settings(color_stage_2)  -smooth $::settings(profile_graph_smoothing_technique) -pixels [rescale_x_skin 30]; 
 	$widget element create line_espresso_de1_explanation_chart_flow_part3 -xdata espresso_de1_explanation_chart_elapsed_flow_3 -ydata espresso_de1_explanation_chart_flow_3 -symbol circle -label "" -linewidth [rescale_x_skin 50] -color $::settings(color_stage_3)  -smooth $::settings(profile_graph_smoothing_technique) -pixels [rescale_x_skin 30]; 
@@ -460,10 +466,10 @@ proc apply_range_to_all_steps {ignored} {
 
 # limits
 add_de1_text "settings_2c2" 70 830 -text [translate "Limit flow range"] -font Helv_10_bold -fill "#7f879a" -anchor "nw" -width [rescale_x_skin 1600] -justify "center"
-add_de1_widget "settings_2c2" scale 70 900  {} -from 0 -to 8  -background $::settings(color_stage_2)  -showvalue 0 -borderwidth 1 -bigincrement 1 -resolution 0.1 -length [rescale_x_skin 700] -width [rescale_x_skin 120] -variable ::settings(maximum_flow_range_advanced)     -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command "apply_range_to_all_steps" -foreground #FFFFFF -troughcolor $slider_trough_color -borderwidth 0  -highlightthickness 0 -orient horizontal 
+add_de1_widget "settings_2c2" scale 70 900  {} -from 0 -to $::de1(max_flowrate_v11)  -background $::settings(color_stage_2)  -showvalue 0 -borderwidth 1 -bigincrement 1 -resolution 0.1 -length [rescale_x_skin 700] -width [rescale_x_skin 120] -variable ::settings(maximum_flow_range_advanced)     -font Helv_15_bold -sliderlength [rescale_x_skin 125] -relief flat -command "apply_range_to_all_steps" -foreground #FFFFFF -troughcolor $slider_trough_color -borderwidth 0  -highlightthickness 0 -orient horizontal 
 add_de1_variable "settings_2c2" 70 1020 -text "" -font Helv_8 -fill "#4e85f4" -anchor "nw" -width [rescale_x_skin 1200] -justify "left" -textvariable {$::settings(maximum_flow_range_advanced) [translate mL/s]}
 #add_de1_button "settings_2c2" { profile_has_changed_set; dui page open_dialog dui_number_editor ::settings(maximum_flow_range_advanced) -n_decimals 1 -min 0.1 -max 8 -default $::settings(maximum_flow_range_advanced) -smallincrement 0.1 -bigincrement 1 -use_biginc 1 -page_title [translate "Limit flow range"] -previous_values [::dui::pages::dui_number_editor::get_previous_values maximum_flow_range_advanced] -return_callback "::dui::pages::dui_number_editor::save_previous_value callback_after_adv_profile_data_entry maximum_flow_range_advanced"  } 50 830 600 894 ""   
-add_de1_button "settings_2c2" { profile_has_changed_set; dui page open_dialog dui_number_editor ::settings(maximum_flow_range_advanced) -n_decimals 1 -min 0.1 -max 8 -default $::settings(maximum_flow_range_advanced) -smallincrement 0.1 -bigincrement 1 -use_biginc 1 -page_title [translate "Limit flow range"] -previous_values [::dui::pages::dui_number_editor::get_previous_values maximum_flow_range_advanced] -return_callback "::dui::pages::dui_number_editor::save_previous_value callback_after_adv_profile_data_entry maximum_flow_range_advanced"  } 50 1024 600 1100 ""   
+add_de1_button "settings_2c2" { profile_has_changed_set; dui page open_dialog dui_number_editor ::settings(maximum_flow_range_advanced) -n_decimals 1 -min 0.1 -max $::de1(max_flowrate_v11) -default $::settings(maximum_flow_range_advanced) -smallincrement 0.1 -bigincrement 1 -use_biginc 1 -page_title [translate "Limit flow range"] -previous_values [::dui::pages::dui_number_editor::get_previous_values maximum_flow_range_advanced] -return_callback "::dui::pages::dui_number_editor::save_previous_value callback_after_adv_profile_data_entry maximum_flow_range_advanced"  } 50 1024 600 1100 ""
 
 
 
@@ -966,6 +972,12 @@ add_de1_widget "settings_1b" graph 1330 300 {
 		$::preview_graph_flow element create line_espresso_de1_explanation_chart_flow -xdata espresso_de1_explanation_chart_elapsed -ydata espresso_de1_explanation_chart_flow -symbol circle -label "" -linewidth [rescale_x_skin 10] -color #98c5ff  -smooth $::settings(profile_graph_smoothing_technique) -pixels 0; 
 		$::preview_graph_flow axis configure x -color #5a5d75 -tickfont Helv_6; 
 		$::preview_graph_flow axis configure y -color #5a5d75 -tickfont Helv_6 -min 0.0 -max 10 -majorticks {1 2 3 4 5 6 7 8 9 10} -title [translate "Flow rate"] -titlefont Helv_8 -titlecolor #5a5d75;
+		if {$::de1(max_flowrate_v11) >= 16} {
+			set _flow_ticks {0 4 8 12 16 20}
+		} else {
+			set _flow_ticks {1 2 3 4 5 6 7 8 9 10}
+		}
+		$::preview_graph_flow axis configure y -color #5a5d75 -tickfont Helv_6 -min 0.0 -max [expr {$::de1(max_flowrate_v11) + 1}] -majorticks $_flow_ticks -title [translate "Flow rate"] -titlefont Helv_8 -titlecolor #5a5d75;
 		$::preview_graph_flow element create line_espresso_de1_explanation_chart_temp -xdata espresso_de1_explanation_chart_elapsed_flow -ydata espresso_de1_explanation_chart_temperature_10  -label "" -linewidth [rescale_x_skin 10] -color #ff888c  -smooth $::settings(preview_graph_smoothing_technique) -pixels 0; 
 		bind $::preview_graph_flow [platform_button_press] { show_profile_editor {} }
 	} -plotbackground $chart_background_color -width [rescale_x_skin 1050] -height [rescale_y_skin 450] -borderwidth 1 -background #FFFFFF -plotrelief raised  -plotpady 0 -plotpadx 10

--- a/de1plus/vars.tcl
+++ b/de1plus/vars.tcl
@@ -3940,6 +3940,10 @@ proc de1_version_string {} {
 	}
 	
 	array set modelarr [list 0 [translate "unknown"] 1 DE1 2 DE1+ 3 DE1PRO 4 DE1XL 5 DE1CAFE 6 DE1XXL 7 DE1XXXL]
+	# Model 128 and above is Bengle hardware (a range, not one value).
+	if {[::de1::packet::is_bengle_model_value [ifexists ::settings(machine_model) ""]]} {
+		set modelarr([ifexists ::settings(machine_model)]) "Bengle"
+	}
 
 	set brev ""
 	if {[ifexists ::settings(cpu_board_model)] != ""} {


### PR DESCRIPTION

## Summary

Bengle support already exists here — `is_bengle_model`, the `BENGLE` scan-name match, and
the Bengle gate on `set_cupwarmer_temperature`, all added in `ee1a5da`. This PR replaces
the detection behind it and adds the protocol selector the rest of the Bengle series
depends on. Behaviour on a DE1 is unchanged apart from two scan-list bug fixes.

## Why the existing detection is not enough

`is_bengle_model` reads the BLE-advertised name, which is persisted to `settings.tdb`.
That breaks two ways:

- **Auto-reconnect never rescans.** `::de1_device_list` is empty, so `de1_ble` falls back
  to the literal `"DE1"` and overwrites the persisted value. A Bengle then reads as a DE1
  until someone runs a manual scan.
- **A stale name survives a firmware change.** `append_to_de1_list` returns early on a
  duplicate address, so a scan cannot correct a name already seeded from settings.

The model number has neither problem. It arrives from the `v13Model` MMR at `0x0080000C`
on every connect, from the machine.

## Changes

**`de1_de1.tcl`** — `is_bengle_model_value` (model **128 and above**, a range not a single
value, matching `isBengleModelValue` in `decentespresso/decaid`),
`detect_ble_protocol_version`, `set_ble_protocol_version`, `use_ble_v2`, and a write trace
on `::settings(machine_model)` so every connect path is covered without editing each one.

**`de1_comms.tcl`** — `is_bengle_model` returns `use_ble_v2`. `append_to_de1_list`
replaces rather than skips a duplicate address. Adds `long32_to_little_endian_hex`, a
32-bit companion to the existing 16-bit helper.

**`bluetooth.tcl`** — a connect with no scan entry keeps the persisted model instead of
overwriting it with `"DE1"`.

**`machine.tcl`** — `ble_protocol_version 1`.

**`vars.tcl`** — model 128 and above displays as `Bengle`.

**`skins/default/de1_skin_settings.tcl`** — the flow chart axes, their tick marks and two
`settings_2c2` editors follow `max_flowrate_v11` instead of a hardcoded 8 or 10.

## Flow rate

`::de1(max_flowrate_v11)` goes 8 → 20 mL/s on a Bengle and stays 8 on a DE1. That is the
live ceiling: `vars.tcl` range-checks three settings against it and the default skin reads
it for 16 slider and editor bounds, so the UI follows the machine.

The `_v11` name is now a misnomer. Renaming it would touch the default skin in 16 places
and is left for a separate change. `::de1(max_flowrate)` is untouched; nothing live reads
it.

## Why `use_ble_v2` has no caller here

It is the predicate the Bengle follow-ups gate on, and it is in this PR because the
detection that sets it is here. The same applies to `long32_to_little_endian_hex`: LED
colours are 24-bit, the machine clock runs to 604800, and the schedule word packs the day
into bits 31:22, so four later PRs need it. Defining it once here avoids four conflicting
copies.

## Test plan

- [x] `is_bengle_model_value` returns 0 for 1, 127, empty and non-numeric input, and 1 for
      128 and 129 — run in `tclsh`.
- [x] The write trace flips both the protocol and the flow ceiling in both directions.
- [ ] Connect a DE1. Confirm the info page names the correct model and the flow sliders
      still stop at 8 mL/s.
- [ ] TODO (Ben): connect a Bengle. Confirm the info page reads `Bengle` and the sliders
      reach 20 mL/s.
- [ ] TODO (Ben): restart the tablet and let it auto-reconnect with no scan. Confirm the
      machine is still identified correctly.

## Testing

Manual verification plus the two `tclsh` checks above. There is no automated test coverage
for these Tcl paths in the repo.
